### PR TITLE
Provide UI configuration for strategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.durabletask.executors;
 
 import hudson.model.Computer;
+import hudson.model.Descriptor;
 import hudson.model.Executor;
 import hudson.model.ExecutorListener;
 import hudson.model.Queue;
@@ -32,8 +33,12 @@ import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.EphemeralNode;
+import hudson.slaves.RetentionStrategy;
 import hudson.util.TimeUnit2;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -49,12 +54,13 @@ public final class OnceRetentionStrategy extends CloudRetentionStrategy implemen
 
     private transient boolean terminating;
     
-    private int idleMinutes;
+    protected int idleMinutes;
 
     /**
      * Creates the retention strategy.
      * @param idleMinutes number of minutes of idleness after which to kill the slave; serves a backup in case the strategy fails to detect the end of a task
      */
+    @DataBoundConstructor
     public OnceRetentionStrategy(int idleMinutes) {
         super(idleMinutes);
         this.idleMinutes = idleMinutes;
@@ -140,4 +146,18 @@ public final class OnceRetentionStrategy extends CloudRetentionStrategy implemen
         });
     }
 
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+    public static final class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
+        @Override
+        public String getDisplayName() {
+            return "Once Retention Strategy";
+        }
+    }
 }

--- a/src/main/resources/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy/config.groovy
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy
+
+def f = namespace(lib.FormTagLib);
+
+f.entry(title: "Idle timeout", field: "idleMinutes") {
+    f.number(default: 0)
+}

--- a/src/main/resources/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy/help-idleMinutes.html
+++ b/src/main/resources/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy/help-idleMinutes.html
@@ -1,0 +1,4 @@
+<div>
+    Number of minutes of idleness after which to kill the slave;
+    serves a backup in case the strategy fails to detect the end of a task
+</div>


### PR DESCRIPTION
There are different ways of using strategies with UI configuration:
- do wrappers in all plugins that using it, 
- subclass (private fields is pain) 
- just provide normal Describable

This PR:
- Provides UI configuration for strategy
- Suggest good idle timeout (example references in comments)

Every slave instance should have copy of this strategy because of 'idle' field, should this class be `Cloneable` to get configured copies?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/durable-task-plugin/6)

<!-- Reviewable:end -->
