### PR TITLE
Do not kill a one-shot slave merely because a flyweight task happened to run on it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.durabletask.executors;
 import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.ExecutorListener;
+import hudson.model.OneOffExecutor;
 import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
@@ -96,6 +97,10 @@ public final class OnceRetentionStrategy extends CloudRetentionStrategy implemen
     private void done(Executor executor) {
         final AbstractCloudComputer<?> c = (AbstractCloudComputer) executor.getOwner();
         Queue.Executable exec = executor.getCurrentExecutable();
+        if (executor instanceof OneOffExecutor) {
+            LOGGER.log(Level.FINE, "not terminating {0} because {1} was a flyweight task", new Object[] {c.getName(), exec});
+            return;
+        }
         if (exec instanceof ContinuableExecutable && ((ContinuableExecutable) exec).willContinue()) {
             LOGGER.log(Level.FINE, "not terminating {0} because {1} says it will be continued", new Object[] {c.getName(), exec});
             return;


### PR DESCRIPTION
Complements https://github.com/jenkinsci/branch-api-plugin/pull/5. Either suffice to fix the problem, but better to have both.

@reviewbybees