### PR TITLE
[JENKINS-32701] Escape percentage signs in the jenkins-wrapper batch 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -55,9 +55,9 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         BatchController c = new BatchController(ws);
 
         c.getBatchFile1(ws).write(String.format("cmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
-                c.getBatchFile2(ws),
-                c.getLogFile(ws),
-                c.getResultFile(ws)
+                c.getBatchFile2(ws).getRemote().replace("%", "%%"),
+                c.getLogFile(ws).getRemote().replace("%", "%%"),
+                c.getResultFile(ws).getRemote().replace("%", "%%")
         ), "UTF-8");
         c.getBatchFile2(ws).write(script, "UTF-8");
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -49,17 +49,21 @@ public class WindowsBatchScriptTest {
 
     @Issue("JENKINS-25678")
     @Test public void spaceInPath() throws Exception {
-        doSpaceInPath("space in path");
+        testWithPath("space in path");
     }
 
     @Issue("JENKINS-25678")
     @Test public void spaceInPath2() throws Exception {
-        doSpaceInPath("space in path@2");
+        testWithPath("space in path@2");
     }
 
-    private void doSpaceInPath(String name) throws Exception {
+    @Test public void percentInPath2() throws Exception {
+        testWithPath("percent%in%path@2");
+    }
+
+    private void testWithPath(String path) throws Exception {
         StreamTaskListener listener = StreamTaskListener.fromStdout();
-        FilePath ws = j.jenkins.getRootPath().child(name);
+        FilePath ws = j.jenkins.getRootPath().child(path);
         Launcher launcher = j.jenkins.createLauncher(listener);
         Controller c = new WindowsBatchScript("echo hello world").launch(new EnvVars(), ws, launcher, listener);
         while (c.exitStatus(ws, launcher) == null) {


### PR DESCRIPTION
When writing workspace paths into the `jenkins-wrapper.bat` batch
script, percentage signs need to be escaped correctly. Otherwise
the batch script execution will silently fail when the workspace
path contains a percentage sign. This was encountered in a multi branch
workflow project.