### PR TITLE
Reverting change made in https://github.com/jenkinsci/durable-task-pl…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -63,10 +63,11 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         Launcher.ProcStarter ps = launcher.launch().cmds("cmd", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(envVars).pwd(ws).quiet(true);
         listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+\\\\", "") + "] Running batch script"); // details printed by cmd
-        /* Too noisy, and consumes a thread:
+        
         ps.stdout(listener);
-        */
-        ps.readStdout().readStderr(); // TODO see BourneShellScript
+        
+        /*ps.readStdout().readStderr(); // TODO see BourneShellScript */
+        
         ps.start();
         return c;
     }


### PR DESCRIPTION
…ugin/commit/7b17a50395bc9be08926dec1ff44005696a61c9e

Trouble shooting issue https://issues.jenkins-ci.org/browse/JENKINS-34150
With loging of batch processing the hang/silent fail of Batch jobs does not occur.
The extra thread may be covering some other race condition in durabletasks.  Possibly when result file is checked for existince and batch is trying to write to it at the same time. Lock/thread race condition.
