### PR TITLE
[JENKINS-34647] Migrate to 2.x parent pom.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ work
 *.iws
 *.iml
 *.ipr
+.settings
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.609.1</version>
+        <version>2.7</version>
     </parent>
     <artifactId>durable-task</artifactId>
     <version>1.10-SNAPSHOT</version>
@@ -17,19 +17,13 @@
             <url>http://www.opensource.org/licenses/mit-license.php</url>
         </license>
     </licenses>
+    
     <properties>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <jenkins.version>1.609.1</jenkins.version>
+      <java.level>6</java.level>
+      <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
-    <dependencies>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
+    
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -42,21 +36,6 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
-                <configuration>
-                    <xmlOutput>true</xmlOutput>
-                    <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-                    <failOnError>false</failOnError>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>


### PR DESCRIPTION
[JENKINS-34647](https://issues.jenkins-ci.org/browse/JENKINS-34647)

Migrate to 2.7 parent pom. Ignore Findbugs errors for now. 

@reviewbybees 