### PR TITLE
[JENKINS-34150] Fixes my observed issue.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -54,7 +54,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         }
         BatchController c = new BatchController(ws);
 
-        c.getBatchFile1(ws).write(String.format("cmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
+        c.getBatchFile1(ws).write(String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
                 c.getBatchFile2(ws).getRemote().replace("%", "%%"),
                 c.getLogFile(ws).getRemote().replace("%", "%%"),
                 c.getResultFile(ws).getRemote().replace("%", "%%")


### PR DESCRIPTION
I have a reproducable tests case in a propratary implementation using this
code that is 100% reproducable.
The simple "`@echo off`" fixes the failing test for me.

It seems that in the case that the parent process has been killed (e.g.
the slave dies) then all though the script terminates successfully and the
wrapper terminates successfully (checked with process monitor) there is no
attempt to create the result file.
where the parent process has not been killed I never see this issue.
All I needed to do to fix the issue I was observing is add `@echo off` as
the first line of the wrapper script. Basically I believe as it is trying to
echo the commands to be run before running the commands and as there is no
longer anything consuming the wrappers input/output when echoing the
command it is doomed to fail (but strangely not with an exit code that
implies something died!??!

@reviewbybees
https://issues.jenkins-ci.org/browse/JENKINS-34150