### PR TITLE
Update to see the sh output

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -125,7 +125,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         if (!ws.act(new DarwinCheck())) { // JENKINS-25848
             args.add("nohup");
         }
-        args.addAll(Arrays.asList("sh", "-c", cmd));
+        args.addAll(Arrays.asList("sh", "-xc", cmd));
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(envVars).pwd(ws).quiet(true);
         listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+/", "") + "] Running shell script"); // -x will give details
         boolean novel;


### PR DESCRIPTION
This approach is really helpful to be able to spot issues within the shell scripts. Currently the only way to retrieve the std out while the script runs is 
sh 'sh -xc "ls -la"' that is very ugly.