### PR TITLE
[JENKINS-40734] Escape $ in environment variable values so it does not get expanded by Launcher

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -126,7 +126,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             args.add("nohup");
         }
         args.addAll(Arrays.asList("sh", "-c", cmd));
-        Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(envVars).pwd(ws).quiet(true);
+        Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+/", "") + "] Running shell script"); // -x will give details
         boolean novel;
         synchronized (encounteredPaths) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -77,6 +79,17 @@ public abstract class FileMonitoringTask extends DurableTask {
      */
     protected FileMonitoringController doLaunch(FilePath workspace, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
         throw new AbstractMethodError("override either doLaunch or launchWithCookie");
+    }
+
+    /**
+     * JENKINS-40734: blocks the substitutions of {@link EnvVars#overrideExpandingAll} done by {@link Launcher}.
+     */
+    protected static Map<String, String> escape(EnvVars envVars) {
+        Map<String, String> m = new TreeMap<String, String>();
+        for (Map.Entry<String, String> entry : envVars.entrySet()) {
+            m.put(entry.getKey(), entry.getValue().replace("$", "$$"));
+        }
+        return m;
     }
 
     protected static class FileMonitoringController extends Controller {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -75,7 +75,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         c.getBatchFile1(ws).write(cmd, "UTF-8");
         c.getBatchFile2(ws).write(script, "UTF-8");
 
-        Launcher.ProcStarter ps = launcher.launch().cmds("cmd", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(envVars).pwd(ws).quiet(true);
+        Launcher.ProcStarter ps = launcher.launch().cmds("cmd", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(escape(envVars)).pwd(ws).quiet(true);
         listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+\\\\", "") + "] Running batch script"); // details printed by cmd
         /* Too noisy, and consumes a thread:
         ps.stdout(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -138,4 +138,17 @@ public class BourneShellScriptTest extends Assert {
         c.cleanup(ws);
     }
 
+    @Issue("JENKINS-40734")
+    @Test public void envWithShellChar() throws Exception {
+        Controller c = new BourneShellScript("echo \"value=$MYNEWVAR\"").launch(new EnvVars("MYNEWVAR", "foo$$bar"), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws,baos);
+        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertThat(baos.toString(), containsString("value=foo$$bar"));
+        c.cleanup(ws);
+    }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -31,6 +31,7 @@ import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import org.apache.commons.io.output.TeeOutputStream;
+import static org.hamcrest.Matchers.containsString;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Assume;
@@ -115,6 +116,19 @@ public class WindowsBatchScriptTest {
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
         assertEquals("42\r\n", new String(c.getOutput(ws, launcher)));
+        c.cleanup(ws);
+    }
+
+    @Issue("JENKINS-40734")
+    @Test public void envWithShellChar() throws Exception {
+        Controller c = new WindowsBatchScript("echo value=%MYNEWVAR%").launch(new EnvVars("MYNEWVAR", "foo$$bar"), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws,baos);
+        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertThat(baos.toString(), containsString("value=foo$$bar"));
         c.cleanup(ws);
     }
 


### PR DESCRIPTION
[JENKINS-40734](https://issues.jenkins-ci.org/browse/JENKINS-40734)

@reviewbybees