### PR TITLE
Fixes 'isAlive' check for remotes connected through Cygwin.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
@@ -84,7 +84,7 @@ final class ProcessLiveness {
         } else {
             // Using a special launcher; let it decide how to do this.
             // TODO perhaps this should be a method in Launcher, with the following fallback in DecoratedLauncher:
-            return launcher.launch().cmds("ps", "-o", "pid=", Integer.toString(pid)).quiet(true).join() == 0;
+            return launcher.launch().cmds("ps", "-p", Integer.toString(pid)).quiet(true).join() == 0;
         }
     }
 


### PR DESCRIPTION
The isAlive check relies on 'ps -o pid= xxx' invocation to determine liveliness of a task.

As Cygwin's 'ps' does not offer the '-o' option, this invocation always returns a non-zero value, interpreted by the rest of the code as if the task completed.

The proposed fix is to make a simpler usage, in the form 'ps -p xxx', which seems to be valid on most Unix(-like) platforms.