### PR TITLE
retry on accessing pid file for bourne shell

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -179,10 +179,20 @@ public final class BourneShellScript extends FileMonitoringTask {
             if (pid == 0) {
                 FilePath pidFile = pidFile(ws);
                 if (pidFile.exists()) {
-                    try {
-                        pid = Integer.parseInt(pidFile.readToString().trim());
-                    } catch (NumberFormatException x) {
-                        throw new IOException("corrupted content in " + pidFile + ": " + x, x);
+                    for ( int tries = 30; tries > 0; tries-- ) {
+                        String _pid = "";
+                        try {
+                            _pid = pidFile.readToString().trim();
+                            pid = Integer.parseInt(_pid);
+                        } catch (NumberFormatException x) {
+                            if ( tries == 1 ) {
+                                throw new IOException("corrupted content in " + pidFile + ": " + x, x);
+                            }
+                            if ( tries != 1 && _pid.length() == 0) {
+                                // potential timing issue where pid file created but not yet populated
+                                Thread.sleep(100);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
We have itermittently ran into the following type of exception:

```
java.io.IOException: corrupted content in /var/lib/jenkins/jobs/qwer/workspace@tmp/durable-129c54bd/pid: java.lang.NumberFormatException: For input string: ""
	at org.jenkinsci.plugins.durabletask.BourneShellScript$ShellController.pid(BourneShellScript.java:175)
	at org.jenkinsci.plugins.durabletask.BourneShellScript$ShellController.exitStatus(BourneShellScript.java:187)
```

But when we then look at the `/var/lib/jenkins/jobs/qwer/workspace@tmp/durable-129c54bd/pid` after the exception has occurred, it in fact has a valid PID in it.

The implication being that a timing window between when the pid file is created and when it is populated occurred.

I attempted some quick research into commits/issues/jiras to see if such an item has been discussed and mitigated in the past and found none (apologies if my search was not suffiicient).

In any event here is a proposed code change to address for all users of the plugin (vs. our code doing something similar around our calls to `exitStatus`).

Thoughts?  thanks and regards