### PR TITLE
[JENKINS-39307] fixed missing EnvVars in ps command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
@@ -162,7 +163,9 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         private int pid;
         private final long startTime = System.currentTimeMillis();
-        private EnvVars envVars = new EnvVars();
+
+        @CheckForNull
+        private EnvVars envVars;
 
         private ShellController(FilePath ws, EnvVars envVars) throws IOException, InterruptedException {
             super(ws);
@@ -197,8 +200,9 @@ public final class BourneShellScript extends FileMonitoringTask {
                 return status;
             }
             int _pid = pid(workspace);
+            EnvVars vars = envVars == null ? new EnvVars() : envVars;
 
-            if (_pid > 0 && !ProcessLiveness.isAlive(workspace.getChannel(), _pid, launcher, envVars)) {
+            if (_pid > 0 && !ProcessLiveness.isAlive(workspace.getChannel(), _pid, launcher, vars)) {
                 // it looks like the process has disappeared. one last check to make sure it's not a result of a race condition,
                 // then if we still don't have the exit code, use fake exit code to distinguish from 0 (success) and 1+ (observed failure)
                 // TODO would be better to have exitStatus accept a TaskListener so we could print an informative message

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -62,7 +62,7 @@ public final class BourneShellScript extends FileMonitoringTask {
     @DataBoundConstructor public BourneShellScript(String script) {
         this.script = Util.fixNull(script);
     }
-
+    
     public String getScript() {
         return script;
     }
@@ -162,7 +162,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         private int pid;
         private final long startTime = System.currentTimeMillis();
-        private EnvVars envVars;
+        private EnvVars envVars = new EnvVars();
 
         private ShellController(FilePath ws, EnvVars envVars) throws IOException, InterruptedException {
             super(ws);
@@ -197,7 +197,8 @@ public final class BourneShellScript extends FileMonitoringTask {
                 return status;
             }
             int _pid = pid(workspace);
-            if (_pid > 0 && !ProcessLiveness.isAlive(workspace.getChannel(), _pid, launcher, this.envVars)) {
+
+            if (_pid > 0 && !ProcessLiveness.isAlive(workspace.getChannel(), _pid, launcher, envVars)) {
                 // it looks like the process has disappeared. one last check to make sure it's not a result of a race condition,
                 // then if we still don't have the exit code, use fake exit code to distinguish from 0 (success) and 1+ (observed failure)
                 // TODO would be better to have exitStatus accept a TaskListener so we could print an informative message

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -62,7 +62,7 @@ public final class BourneShellScript extends FileMonitoringTask {
     @DataBoundConstructor public BourneShellScript(String script) {
         this.script = Util.fixNull(script);
     }
-    
+
     public String getScript() {
         return script;
     }
@@ -87,7 +87,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             listener.getLogger().println("Warning: was asked to run an empty script");
         }
 
-        ShellController c = new ShellController(ws);
+        ShellController c = new ShellController(ws, envVars);
 
         FilePath shf = c.getScriptFile(ws);
 
@@ -162,9 +162,11 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         private int pid;
         private final long startTime = System.currentTimeMillis();
+        private EnvVars envVars;
 
-        private ShellController(FilePath ws) throws IOException, InterruptedException {
+        private ShellController(FilePath ws, EnvVars envVars) throws IOException, InterruptedException {
             super(ws);
+            this.envVars = envVars;
         }
 
         public FilePath getScriptFile(FilePath ws) throws IOException, InterruptedException {
@@ -195,7 +197,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                 return status;
             }
             int _pid = pid(workspace);
-            if (_pid > 0 && !ProcessLiveness.isAlive(workspace.getChannel(), _pid, launcher)) {
+            if (_pid > 0 && !ProcessLiveness.isAlive(workspace.getChannel(), _pid, launcher, this.envVars)) {
                 // it looks like the process has disappeared. one last check to make sure it's not a result of a race condition,
                 // then if we still don't have the exit code, use fake exit code to distinguish from 0 (success) and 1+ (observed failure)
                 // TODO would be better to have exitStatus accept a TaskListener so we could print an informative message

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -84,7 +84,7 @@ public abstract class FileMonitoringTask extends DurableTask {
     /**
      * JENKINS-40734: blocks the substitutions of {@link EnvVars#overrideExpandingAll} done by {@link Launcher}.
      */
-    static Map<String, String> escape(EnvVars envVars) {
+    protected static Map<String, String> escape(EnvVars envVars) {
         Map<String, String> m = new TreeMap<String, String>();
         for (Map.Entry<String, String> entry : envVars.entrySet()) {
             m.put(entry.getKey(), entry.getValue().replace("$", "$$"));

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -84,7 +84,7 @@ public abstract class FileMonitoringTask extends DurableTask {
     /**
      * JENKINS-40734: blocks the substitutions of {@link EnvVars#overrideExpandingAll} done by {@link Launcher}.
      */
-    protected static Map<String, String> escape(EnvVars envVars) {
+    static Map<String, String> escape(EnvVars envVars) {
         Map<String, String> m = new TreeMap<String, String>();
         for (Map.Entry<String, String> entry : envVars.entrySet()) {
             m.put(entry.getKey(), entry.getValue().replace("$", "$$"));


### PR DESCRIPTION
This PR adds the env vars from the shell command to the corresponding ps command.

This fixes the following problem: https://issues.jenkins-ci.org/browse/JENKINS-39307

The cause for the unexpected abort is the following:

When starting a docker container on a different docker-Host, set by the env-var DOCKER_HOST, the sh commands get correctly piped through to the container, but the ps command will not go to the correct docker host, because the env vars are not set.

In our setup we run Jenkins in a docker container and use the same docker-host to run the pipeline docker containers. This means that we have to explicitely set the DOCKER_HOST to something different than localhost.

To reproduce, run the following script, but set the DOCKER_HOST on the node to an external Host. The "sleep 10" command will be aborted and the echo will never run.

```
pipeline {
    agent {
        docker {
            image 'ubuntu:16.04'
        }
    }
    stages {
        stage('Run') {
            steps {
                sh 'sleep 10'
                sh 'echo "Test"'
        }
    }
}
```