### PR TITLE
[JENKINS-38682] - Use waitpid to poll for process liveness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-constants</artifactId>
+            <version>0.9.10-SNAPSHOT</version>
+        </dependency>
+        <!-- Commented out until we can assume new jnr-posix >= 3.0.42 is in
+             core due to the need for waitpid on Windows.
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-posix</artifactId>
+            <version>3.0.42-SNAPSHOT</version>
+        </dependency>
+        -->
+    </dependencies>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
@@ -150,6 +150,8 @@ final class ProcessLiveness {
                 LOGGER.log(Level.WARNING, fallback_msg, x);
             } catch (NoSuchMethodException x) {
                 LOGGER.log(Level.WARNING, fallback_msg, x);
+            } catch (SecurityException x) {
+                LOGGER.log(Level.WARNING, fallback_msg, x);
             }
 
             // JNR-POSIX used to fail on FreeBSD at least, so try JNA as well.


### PR DESCRIPTION
This reverts commit 3c10cc0cb0a4738646966494fbeaab54bca115e1 which
moved the process liveness checking implementation from JNR to JNA.
This broke on Windows as there is no shared libc available.

Instead, we move back to JNR, but using waitpid instead of getpgid to
perform the polling. This is a generic enough interfacec that it should
have very consistent support across POSIX operating systems and can even
be supported on Windows (in a future JNR release).

Finally, I believe the original motivation cited for moving to JNA in
3c10cc0 no longer applies; I have no trouble using this plugin with
current JNR and FreeBSD-11.0.

Fixes [JENKINS-38682](https://issues.jenkins-ci.org/browse/JENKINS-38682).