### PR TITLE
Fixing issues with unicode characters in PowerShell

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -40,6 +40,8 @@ import java.io.IOException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 /**
  * Runs a Powershell script
@@ -47,7 +49,7 @@ import java.io.InputStreamReader;
 public final class PowershellScript extends FileMonitoringTask {
     private final String script;
     private boolean capturingOutput;
-
+    
     @DataBoundConstructor public PowershellScript(String script) {
         this.script = script;
     }
@@ -67,30 +69,83 @@ public final class PowershellScript extends FileMonitoringTask {
         
         String cmd;
         if (capturingOutput) {
-            cmd = String.format("$(& \"%s\" | Out-File -FilePath \"%s\" -Encoding UTF8) 2>&1 3>&1 4>&1 5>&1 | Out-File -FilePath \"%s\" -Encoding UTF8; $LastExitCode | Out-File -FilePath \"%s\" -Encoding ASCII; $outputWithBom = Get-Content \"%s\"; [IO.File]::WriteAllLines(\"%s\", $outputWithBom);", 
-                quote(c.getPowershellMainFile(ws)),
-                quote(c.getTemporaryOutputFile(ws)),
+            cmd = String.format(". \"%s\"; Execute-AndWriteOutput -MainScript \"%s\" -OutputFile \"%s\" -LogFile \"%s\" -ResultFile \"%s\" -CaptureOutput;", 
+                quote(c.getPowerShellHelperFile(ws)),
+                quote(c.getPowerShellWrapperFile(ws)),
+                quote(c.getOutputFile(ws)),
                 quote(c.getLogFile(ws)),
-                quote(c.getResultFile(ws)),
-                quote(c.getTemporaryOutputFile(ws)),
-                quote(c.getOutputFile(ws)));
+                quote(c.getResultFile(ws)));
         } else {
-            cmd = String.format("& \"%s\" *>&1 | Out-File -FilePath \"%s\" -Encoding UTF8; $LastExitCode | Out-File -FilePath \"%s\" -Encoding ASCII;",
-                quote(c.getPowershellMainFile(ws)),
+            cmd = String.format(". \"%s\"; Execute-AndWriteOutput -MainScript \"%s\" -LogFile \"%s\" -ResultFile \"%s\";",
+                quote(c.getPowerShellHelperFile(ws)),
+                quote(c.getPowerShellWrapperFile(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));
         }
-
-        // Write the script and execution wrapper to powershell files in the workspace
-        c.getPowershellScriptFile(ws).write(script, "UTF-8");
-        c.getPowershellMainFile(ws).write("try {\r\n& '" + quote(c.getPowershellScriptFile(ws)) + "'\r\n} catch {\r\nWrite-Error $_; exit 1;\r\n}\r\nfinally {\r\nif ($LastExitCode -ne $null) {\r\nexit $LastExitCode;\r\n} elseif ($error.Count -gt 0 -or !$?) {\r\nexit 1;\r\n} else {\r\nexit 0;\r\n}\r\n}", "UTF-8");
-        c.getPowershellWrapperFile(ws).write(cmd, "UTF-8");
+       
+        // By default PowerShell adds a byte order mark (BOM) to the beginning of a file when using Out-File with a unicode encoding such as UTF8.
+        // This causes the Jenkins output to contain bogus characters because Java does not handle the BOM characters by default.
+        // This code mimics Out-File, but does not write a BOM.  Hopefully PowerShell will provide a non-BOM option for writing files in future releases.
+        String helperScript = "Function Out-FileNoBom {\n" +
+        "[CmdletBinding()]\n" +
+        "param(\n" +
+        "  [Parameter(Mandatory=$true, Position=0)] [string] $FilePath,\n" +
+        "  [Parameter(ValueFromPipeline=$true)] $InputObject\n" +
+        ")\n" +
+        "  $out = New-Object IO.StreamWriter $FilePath, $false\n" +
+        "  try {\n" +
+        "    $Input | Out-String -Stream | % { $out.WriteLine($_) }\n" +
+        "  } finally {\n" +
+        "    $out.Dispose()\n" +
+        "  }\n" +
+        "}\n" +
+        "Function Execute-AndWriteOutput {\n" +
+        "[CmdletBinding()]\n" +
+        "param(\n" +
+        "  [Parameter(Mandatory=$true)]  [string]$MainScript,\n" +
+        "  [Parameter(Mandatory=$false)] [string]$OutputFile,\n" +
+        "  [Parameter(Mandatory=$true)]  [string]$LogFile,\n" +
+        "  [Parameter(Mandatory=$true)]  [string]$ResultFile,\n" +
+        "  [Parameter(Mandatory=$false)] [switch]$CaptureOutput\n" +
+        ")\n" +
+        "  if ($CaptureOutput -eq $true) {\n" +
+        "      if ($PSVersionTable.PSVersion.Major -ge 5) {\n" +
+        "          $(& $MainScript | Out-FileNoBom -FilePath $OutputFile) 2>&1 3>&1 4>&1 5>&1 6>&1 | Out-FileNoBom -FilePath $LogFile; $LastExitCode | Out-File -FilePath $ResultFile -Encoding ASCII;\n" +
+        "      } else {\n" +
+        "          $(& $MainScript | Out-FileNoBom -FilePath $OutputFile) 2>&1 3>&1 4>&1 5>&1 | Out-FileNoBom -FilePath $LogFile; $LastExitCode | Out-File -FilePath $ResultFile -Encoding ASCII;\n" +
+        "      }\n" +
+        "  } else {\n" +
+        "      & $MainScript *>&1 | Out-FileNoBom -FilePath $LogFile; $LastExitCode | Out-File -FilePath $ResultFile -Encoding ASCII;\n" +
+        "  }\n" +
+        "}";
+        
+        // Execute the script, and catch any errors in order to properly set the jenkins build status. $LastExitCode cannot be solely responsible for determining build status because
+        // there are several instances in which it is not set, e.g. thrown exceptions, and errors that aren't caused by native executables.
+        String wrapperScriptContent = "try {\r\n" + 
+        "  & '" + quote(c.getPowerShellScriptFile(ws)) + "'\r\n" + 
+        "} catch {\r\n" + 
+        "  Write-Error $_;" + 
+        "  exit 1;\r\n" + 
+        "} finally {\r\n" +
+        "  if ($LastExitCode -ne $null) {\r\n" + 
+        "    exit $LastExitCode;\r\n" +
+        "  } elseif ($error.Count -gt 0 -or !$?) {\r\n" + 
+        "    exit 1;\r\n" +
+        "  } else {\r\n" +
+        "    exit 0;\r\n" +
+        "  }\r\n" +
+        "}";
+                   
+        // Write the PowerShell scripts out with a UTF8 BOM
+        writeWithBom(c.getPowerShellHelperFile(ws), helperScript);
+        writeWithBom(c.getPowerShellScriptFile(ws), script);
+        writeWithBom(c.getPowerShellWrapperFile(ws), wrapperScriptContent);
 
         if (launcher.isUnix()) {
             // Open-Powershell does not support ExecutionPolicy
-            args.addAll(Arrays.asList("powershell", "-NonInteractive", "-File", c.getPowershellWrapperFile(ws).getRemote()));
+            args.addAll(Arrays.asList("powershell", "-NonInteractive", "-Command", cmd));
         } else {
-            args.addAll(Arrays.asList("powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", c.getPowershellWrapperFile(ws).getRemote()));    
+            args.addAll(Arrays.asList("powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", cmd));    
         }
 
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
@@ -104,26 +159,32 @@ public final class PowershellScript extends FileMonitoringTask {
     private static String quote(FilePath f) {
         return f.getRemote().replace("$", "`$");
     }
+    
+    // In order for PowerShell to properly read a script that contains unicode characters the script should have a BOM, but there is no built in support for
+    // writing UTF-8 with BOM in Java.  This code writes a UTF-8 BOM before writing the file contents.
+    private static void writeWithBom(FilePath f, String contents) throws IOException, InterruptedException {
+        OutputStream out = f.write();
+        out.write(new byte[] { (byte)0xEF, (byte)0xBB, (byte)0xBF });
+        out.write(contents.getBytes(Charset.forName("UTF-8")));
+        out.flush();
+        out.close();
+    }
 
     private static final class PowershellController extends FileMonitoringController {
         private PowershellController(FilePath ws) throws IOException, InterruptedException {
             super(ws);
         }
-
-        public FilePath getPowershellMainFile(FilePath ws) throws IOException, InterruptedException {
-            return controlDir(ws).child("powershellMain.ps1");
-        }
         
-        public FilePath getPowershellScriptFile(FilePath ws) throws IOException, InterruptedException {
+        public FilePath getPowerShellScriptFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellScript.ps1");
         }
         
-        public FilePath getPowershellWrapperFile(FilePath ws) throws IOException, InterruptedException {
+        public FilePath getPowerShellWrapperFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellWrapper.ps1");
         }
         
-        public FilePath getTemporaryOutputFile(FilePath ws) throws IOException, InterruptedException {
-            return controlDir(ws).child("temporaryOutput.txt");
+        public FilePath getPowerShellHelperFile(FilePath ws) throws IOException, InterruptedException {
+            return controlDir(ws).child("powershellHelper.ps1");
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/resources/org/jenkinsci/plugins/durabletask/PowershellScript/help-script.html
+++ b/src/main/resources/org/jenkinsci/plugins/durabletask/PowershellScript/help-script.html
@@ -1,3 +1,3 @@
 <div>
-    A Powershell Script.  Tested on Powershell 3.x+
+    A Microsoft PowerShell Script.  Tested on Microsoft PowerShell 3.x+
 </div>

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -178,5 +178,19 @@ public class PowershellScriptTest {
         assertThat(baos.toString(), containsString("envvar=power$hell"));
         c.cleanup(ws);
     }
-
+    
+    @Test public void unicodeChars() throws Exception {
+        Controller c = new PowershellScript("Write-Output \"Helló, Wõrld ®\";").launch(new EnvVars(), ws, launcher, listener);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        TeeOutputStream tos = new TeeOutputStream(baos, System.err);
+        while (c.exitStatus(ws, launcher) == null) {
+            c.writeLog(ws, tos);
+            Thread.sleep(100);
+        }
+        c.writeLog(ws, tos);
+        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher));
+        String log = baos.toString("UTF-8");
+        assertTrue(log, log.contains("Helló, Wõrld ®"));
+        c.cleanup(ws);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue that I discovered while using the PowerShell step that causes Unicode characters to not be interpreted properly.  I've also added a new test that checks for proper interpretation of Unicode chars.

Example:
`node {
   powershell 'Write-Output "Hellõ"'
}`

Before this fix:
> ﻿HellÃµ

After this fix:
> Hellõ

PowerShell by default adds a BOM when writing Unicode text out to a file.  This is a bug, and is meant to be fixed soon as per the RFC:
https://github.com/PowerShell/PowerShell-RFC/blob/master/2-Draft-Accepted/RFC0020-DefaultFileEncoding.md
