### PR TITLE
Try to be robust against LinkageError’s from JNA

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
@@ -96,12 +96,16 @@ final class ProcessLiveness {
             this.pid = pid;
         }
         @Override public Boolean call() throws RuntimeException {
-            // JNR-POSIX does not seem to work on FreeBSD at least, so using JNA instead.
-            LibC libc = LibC.INSTANCE;
-            if (libc.getpgid(0) == -1) {
-                throw new IllegalStateException("getpgid does not seem to work on this platform");
+            try {
+                // JNR-POSIX does not seem to work on FreeBSD at least, so using JNA instead.
+                LibC libc = LibC.INSTANCE;
+                if (libc.getpgid(0) == -1) {
+                    throw new IllegalStateException("getpgid does not seem to work on this platform");
+                }
+                return libc.getpgid(pid) != -1;
+            } catch (LinkageError x) {
+                throw new RuntimeException(x);
             }
-            return libc.getpgid(pid) != -1;
         }
     }
     private interface LibC extends Library {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
@@ -58,7 +58,13 @@ final class ProcessLiveness {
         Boolean working = workingLaunchers.get(launcher);
         if (working == null) {
             // Check to see if our logic correctly reports that an unlikely PID is not running.
-            working = !_isAlive(channel, 9999, launcher);
+            int testPID = 9999;
+            int retries = 100;
+            while (_isAlive(null, testPID, /* bypass Liveness/LibC for this */new Launcher.DecoratedLauncher(launcher)) && retries-- > 0) {
+                LOGGER.fine("ignoring PID " + testPID + " which actually does seem to be alive");
+                testPID++;
+            }
+            working = !_isAlive(channel, testPID, launcher);
             workingLaunchers.put(launcher, working);
             if (working) {
                 LOGGER.log(Level.FINE, "{0} on {1} appears to be working", new Object[] {launcher, channel});

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -37,13 +37,16 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Collections;
+import java.util.logging.Level;
 import static org.hamcrest.Matchers.containsString;
 import org.junit.Before;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.LoggerRule;
 
 public class BourneShellScriptTest extends Assert {
 
     @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule public LoggerRule logging = new LoggerRule();
 
     @Before public void unix() {
         Assume.assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
@@ -93,6 +96,7 @@ public class BourneShellScriptTest extends Assert {
     }
 
     @Test public void reboot() throws Exception {
+        logging.record(ProcessLiveness.class, Level.FINER);
         FileMonitoringTask.FileMonitoringController c = (FileMonitoringTask.FileMonitoringController) new BourneShellScript("sleep 999").launch(new EnvVars("killemall", "true"), ws, launcher, listener);
         Thread.sleep(1000);
         launcher.kill(Collections.singletonMap("killemall", "true"));


### PR DESCRIPTION
An installation encountering https://github.com/kohsuke/akuma/issues/15 which would normally be [swallowed here](https://github.com/jenkinsci/jenkins/blob/b649939009f4a8c3356a953ca8d98a96244346c8/core/src/main/java/jenkins/slaves/restarter/UnixSlaveRestarter.java#L29-L45) nonetheless had trouble with warnings printed during Pipeline builds:

```
… FINE    o.j.p.w.s.d.DurableTaskStep$Execution#check: could not check /…
java.lang.UnsatisfiedLinkError: /tmp/jna-…/jna….tmp: /tmp/jna-…/jna….tmp: failed to map segment from shared object: Operation not permitted
    at java.lang.ClassLoader$NativeLibrary.load(Native Method)
    at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:2045)
    at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1928)
    at java.lang.Runtime.load0(Runtime.java:809)
    at java.lang.System.load(System.java:1094)
    at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:851)
    at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:826)
    at com.sun.jna.Native.<clinit>(Native.java:140)
    at com.sun.akuma.CLibrary.<clinit>(CLibrary.java:89)
    at com.sun.akuma.JavaVMArguments.resolvePID(JavaVMArguments.java:128)
    at com.sun.akuma.JavaVMArguments.ofLinux(JavaVMArguments.java:116)
    at com.sun.akuma.JavaVMArguments.of(JavaVMArguments.java:104)
    at com.sun.akuma.JavaVMArguments.current(JavaVMArguments.java:92)
    at jenkins.slaves.restarter.UnixSlaveRestarter.canWork(UnixSlaveRestarter.java:29)
    at jenkins.slaves.restarter.JnlpSlaveRestarterInstaller$2.call(JnlpSlaveRestarterInstaller.java:66)
    at jenkins.slaves.restarter.JnlpSlaveRestarterInstaller$2.call(JnlpSlaveRestarterInstaller.java:52)
Caused: java.lang.NoClassDefFoundError: com/sun/jna/Native : cannot initialize class because prior initialization attempt failed
    at org.jenkinsci.plugins.durabletask.ProcessLiveness$LibC.<clinit>(ProcessLiveness.java:117)
    at org.jenkinsci.plugins.durabletask.ProcessLiveness$Liveness.call(ProcessLiveness.java:98)
    at org.jenkinsci.plugins.durabletask.ProcessLiveness$Liveness.call(ProcessLiveness.java:91)
    at …
Caused: java.lang.NoClassDefFoundError: org/jenkinsci/plugins/durabletask/ProcessLiveness$LibC : cannot initialize class because prior initialization attempt failed
    at org.jenkinsci.plugins.durabletask.ProcessLiveness$Liveness.call(ProcessLiveness.java:98)
    at org.jenkinsci.plugins.durabletask.ProcessLiveness$Liveness.call(ProcessLiveness.java:91)
    at …
    at ......remote call to JNLP4-connect connection from …(Native Method)
    at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1537)
    at hudson.remoting.UserResponse.retrieve(UserRequest.java:253)
    at hudson.remoting.Channel.call(Channel.java:822)
Caused: java.io.IOException: Remote call on JNLP4-connect connection from … failed
    at hudson.remoting.Channel.call(Channel.java:830)
    at org.jenkinsci.plugins.durabletask.ProcessLiveness._isAlive(ProcessLiveness.java:77)
    at org.jenkinsci.plugins.durabletask.ProcessLiveness.isAlive(ProcessLiveness.java:59)
    at org.jenkinsci.plugins.durabletask.BourneShellScript$ShellController.exitStatus(BourneShellScript.java:198)
    at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.check(DurableTaskStep.java:307)
    at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.run(DurableTaskStep.java:276)
    at …
```

Seems we were not catching `LinkageError`s in `ProcessLiveness` correctly, and throwing them up into `exitStatus`.

@reviewbybees