### PR TITLE
fix: use correct syntax ps command that checks if process is alive.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/ProcessLiveness.java
@@ -86,7 +86,7 @@ final class ProcessLiveness {
         } else {
             // Using a special launcher; let it decide how to do this.
             // TODO perhaps this should be a method in Launcher, with the following fallback in DecoratedLauncher:
-            return launcher.launch().cmds("ps", "-o", "pid=", Integer.toString(pid)).quiet(true).start().joinWithTimeout(1, TimeUnit.MINUTES, launcher.getListener())== 0;
+            return launcher.launch().cmds("ps", "-o", "pid", "-p", Integer.toString(pid)).quiet(true).start().joinWithTimeout(1, TimeUnit.MINUTES, launcher.getListener())== 0;
         }
     }
 


### PR DESCRIPTION
Method isAlive internally uses `ps -o pid=<pid>`, to check if a pid exists or not.

I've tried running `ps -o pid=<pid>` in many different system and it always returns 0, regardless of the pid.

As a result when its called like: `ps -o pid=99999` it always return 0, leading eventually to `does not seem able to determine whether processes are alive or not`

I either miss something obvious here, or the command should be `ps -o pid -p <pid>` instead, as this pull request suggest.

