### PR TITLE
Trying to diagnose some ContinuedTaskTest failures

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTaskTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTaskTest.java
@@ -60,7 +60,7 @@ public class ContinuedTaskTest {
         });
         QueueTaskFuture<FreeStyleBuild> b1 = p.scheduleBuild2(0);
         r.jenkins.getQueue().schedule(new TestTask(cntA, false), 0);
-        r.jenkins.getQueue().schedule(new TestTask(cntB, true), 1);
+        r.jenkins.getQueue().schedule(new TestTask(cntB, true), 3);
         // cntB task ought to run first, then b1 and the cntA task in either order
         r.createSlave(label);
         r.assertBuildStatusSuccess(b1);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTaskTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTaskTest.java
@@ -60,7 +60,7 @@ public class ContinuedTaskTest {
         });
         QueueTaskFuture<FreeStyleBuild> b1 = p.scheduleBuild2(0);
         r.jenkins.getQueue().schedule(new TestTask(cntA, false), 0);
-        r.jenkins.getQueue().schedule(new TestTask(cntB, true), 3);
+        r.jenkins.getQueue().schedule(new TestTask(cntB, true), 0);
         // cntB task ought to run first, then b1 and the cntA task in either order
         r.createSlave(label);
         r.assertBuildStatusSuccess(b1);


### PR DESCRIPTION
Saw some presumably unrelated failures in #49:

```
java.lang.AssertionError: expected:<1> but was:<0>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at org.jenkinsci.plugins.durabletask.executors.ContinuedTaskTest$1.perform(ContinuedTaskTest.java:55)
```

@reviewbybees