### PR TITLE
Fixed JENKINS-46876, JENKINS-46508, JENKINS-46496, JENKINS-48057, and JENKINS-47797

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>durable-task</artifactId>
-    <version>1.16</version>
+    <version>1.17-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Durable Task Plugin</name>
     <description>Library offering an extension point for processes which can run outside of Jenkins yet be monitored.</description>
@@ -41,7 +41,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>durable-task-1.16</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -192,15 +192,18 @@ public final class PowershellScript extends FileMonitoringTask {
                                              "  exit $LASTEXITCODE;\r\n" + 
                                              "}", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
         
+        // Add an explicit exit to the end of the script so that exit codes are propagated
+        String scriptWithExit = script + "\r\nexit $LASTEXITCODE;";
+        
         if (launcher.isUnix()) {
             // There is no need to add a BOM with Open PowerShell
             c.getPowerShellHelperFile(ws).write(helperScript, "UTF-8");
-            c.getPowerShellScriptFile(ws).write(script, "UTF-8");
+            c.getPowerShellScriptFile(ws).write(scriptWithExit, "UTF-8");
             c.getPowerShellWrapperFile(ws).write(scriptWrapper, "UTF-8");
         } else {
             // Write the Windows PowerShell scripts out with a UTF8 BOM
             writeWithBom(c.getPowerShellHelperFile(ws), helperScript);
-            writeWithBom(c.getPowerShellScriptFile(ws), script);
+            writeWithBom(c.getPowerShellScriptFile(ws), scriptWithExit);
             writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
         }
         

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -120,7 +120,7 @@ public final class PowershellScript extends FileMonitoringTask {
         ")\r\n" +
         "  $exceptionCaught = $null\r\n" +
         "  try {\r\n" +
-        "    [System.Text.Encoding] $encoding = [System.Text.UTF8Encoding]::new( $false );\r\n" +
+        "    [System.Text.Encoding] $encoding = New-Object System.Text.UTF8Encoding $false;\r\n" +
         "    [System.Console]::OutputEncoding = [System.Console]::InputEncoding = $encoding;\r\n" +
         "    [System.IO.Directory]::SetCurrentDirectory( $PWD );\r\n" +
         "    $null = New-Item $LogFile -ItemType File -Force;\r\n" +

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -153,7 +153,7 @@ public final class PowershellScript extends FileMonitoringTask {
             args.addAll(Arrays.asList("powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", quote(c.getPowerShellMainFile(ws))));    
         }
 
-        Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(false);
+        Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+(\\\\|/)", "") + "] Running PowerShell script");
         ps.readStdout().readStderr();
         ps.start();

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -70,17 +70,17 @@ public final class PowershellScript extends FileMonitoringTask {
         String cmd;
         if (capturingOutput) {
             cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;", 
-                quote(c.getPowerShellHelperFile(ws)),
-                quote(c.getPowerShellWrapperFile(ws)),
-                quote(c.getOutputFile(ws)),
-                quote(c.getLogFile(ws)),
-                quote(c.getResultFile(ws)));
+                c.getPowerShellHelperFile(ws).getRemote(),
+                c.getPowerShellWrapperFile(ws).getRemote(),
+                c.getOutputFile(ws).getRemote(),
+                c.getLogFile(ws).getRemote(),
+                c.getResultFile(ws).getRemote());
         } else {
             cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -LogFile '%s' -ResultFile '%s';",
-                quote(c.getPowerShellHelperFile(ws)),
-                quote(c.getPowerShellWrapperFile(ws)),
-                quote(c.getLogFile(ws)),
-                quote(c.getResultFile(ws)));
+                c.getPowerShellHelperFile(ws).getRemote(),
+                c.getPowerShellWrapperFile(ws).getRemote(),
+                c.getLogFile(ws).getRemote(),
+                c.getResultFile(ws).getRemote());
         }
        
         // By default PowerShell adds a byte order mark (BOM) to the beginning of a file when using Out-File with a unicode encoding such as UTF8.
@@ -181,7 +181,7 @@ public final class PowershellScript extends FileMonitoringTask {
         args.addAll(Arrays.asList(powershellArgs.split(" ")));
         args.addAll(Arrays.asList("-Command", cmd));
         
-        String scriptWrapper = String.format("[CmdletBinding()]\r\nparam()\r\n%s %s -File '%s';", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
+        String scriptWrapper = String.format("[CmdletBinding()]\r\nparam()\r\n%s %s -File '%s';", powershellBinary, powershellArgs, c.getPowerShellScriptFile(ws).getRemote());
                    
         if (launcher.isUnix()) {
             // There is no need to add a BOM with Open PowerShell
@@ -201,10 +201,6 @@ public final class PowershellScript extends FileMonitoringTask {
         ps.start();
 
         return c;
-    }
-    
-    private static String quote(FilePath f) {
-        return f.getRemote().replace("$", "`$");
     }
     
     // In order for PowerShell to properly read a script that contains unicode characters the script should have a BOM, but there is no built in support for

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -185,11 +185,18 @@ public final class PowershellScript extends FileMonitoringTask {
         
         String scriptWrapper = String.format("[CmdletBinding()]\r\nparam()\r\n%s %s -File '%s';", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
                    
-        // Write the PowerShell scripts out with a UTF8 BOM
-        writeWithBom(c.getPowerShellHelperFile(ws), helperScript);
-        writeWithBom(c.getPowerShellScriptFile(ws), script);
-        writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
-
+        if (launcher.isUnix()) {
+            // There is no need to add a BOM with Open PowerShell
+            c.getPowerShellHelperFile(ws).write(helperScript, "UTF-8");
+            c.getPowerShellScriptFile(ws).write(script, "UTF-8");
+            c.getPowerShellWrapperFile(ws).write(scriptWrapper, "UTF-8");
+        } else {
+            // Write the Windows PowerShell scripts out with a UTF8 BOM
+            writeWithBom(c.getPowerShellHelperFile(ws), helperScript);
+            writeWithBom(c.getPowerShellScriptFile(ws), script);
+            writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
+        }
+        
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+(\\\\|/)", "") + "] Running PowerShell script");
         ps.readStdout().readStderr();

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -141,12 +141,12 @@ public final class PowershellScript extends FileMonitoringTask {
         "  } finally {\r\n" +
         "    $exitCode = 0;\r\n" +
         "    if ($LastExitCode -ne $null) {\r\n" +
-        "      if ($LastExitCode -eq 0 -and !$?) {\r\n" +
+        "      if ($LastExitCode -eq 0 -and (!$? -or $exceptionCaught -ne $null)) {\r\n" +
         "        $exitCode = 1;\r\n" +
         "      } else {\r\n" +
         "        $exitCode = $LastExitCode;\r\n" +
         "      }\r\n" +
-        "    } elseif ($exceptionCaught -ne $null -or !$?) {\r\n" +
+        "    } elseif (!$? -or $exceptionCaught -ne $null) {\r\n" +
         "      $exitCode = 1;\r\n" +
         "    }\r\n" +
         "    $exitCode | Out-File -FilePath $ResultFile -Encoding ASCII;\r\n" +

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -124,11 +124,10 @@ public final class PowershellScript extends FileMonitoringTask {
         String wrapperScriptContent = "try {\r\n" + 
         "  & '" + quote(c.getPowerShellScriptFile(ws)) + "'\r\n" + 
         "} catch {\r\n" + 
-        "  Write-Error $_;" + 
-        "  exit 1;\r\n" + 
+        "  Write-Error ($_ | Out-String);\r\n" +
         "} finally {\r\n" +
         "  if ($LastExitCode -ne $null) {\r\n" +
-        "    if ($LastExitCode -eq 0 -and ($error.Count -gt 0 -or !$?)) {\r\n" +
+        "    if ($LastExitCode -eq 0 -and !$?) {\r\n" +
         "      exit 1;\r\n" +
         "    } else {\r\n" +
         "      exit $LastExitCode;\r\n" +

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -133,19 +133,19 @@ public final class PowershellScript extends FileMonitoringTask {
         "    if ($CaptureOutput -eq $true) {\r\n" +
         "        try {\r\n" +
         "          if ($PSVersionTable.PSVersion.Major -ge 5) {\r\n" +
-        "              $(& $MainScript | Out-File -FilePath $OutputFile -Encoding UTF8) 2>&1 3>&1 4>&1 5>&1 6>&1 | Out-FileNoBom -FilePath $LogFile;\r\n" +
+        "              $(& $MainScript | Out-FileNoBom -FilePath $OutputFile) 2>&1 3>&1 4>&1 5>&1 6>&1 | Out-File -FilePath $LogFile -Encoding UTF8;\r\n" +
         "          } else {\r\n" +
-        "              $(& $MainScript | Out-File -FilePath $OutputFile -Encoding UTF8) 2>&1 3>&1 4>&1 5>&1 | Out-FileNoBom -FilePath $LogFile;\r\n" +
+        "              $(& $MainScript | Out-FileNoBom -FilePath $OutputFile) 2>&1 3>&1 4>&1 5>&1 | Out-File -FilePath $LogFile -Encoding UTF8;\r\n" +
         "          }\r\n" +
         "        } finally {\r\n" +
         "          $LastExitCode | Out-File -FilePath $ResultFile -Encoding ASCII;\r\n" +
         "          if (!(Test-Path -Path $OutputFile -PathType Leaf)) {\r\n" +
         "            New-Item -Path $OutputFile -ItemType File;\r\n" +
-        "          } else {\r\n" +
-        "            Remove-BOMFromFile -FilePath $OutputFile\r\n" +
         "          }\r\n" +
         "          if (!(Test-Path -Path $LogFile -PathType Leaf)) {\r\n" +
         "            New-Item -Path $LogFile -ItemType File;\r\n" +
+        "          } else {\r\n" +
+        "            Remove-BOMFromFile -FilePath $LogFile;\r\n" +
         "          }\r\n" +
         "        }\r\n" +
         "    } else {\r\n" +
@@ -156,7 +156,7 @@ public final class PowershellScript extends FileMonitoringTask {
         "          if (!(Test-Path -Path $LogFile -PathType Leaf)) {\r\n" +
         "            New-Item -Path $LogFile -ItemType File;\r\n" +
         "          } else {\r\n" +
-        "            Remove-BOMFromFile -FilePath $LogFile\r\n" +
+        "            Remove-BOMFromFile -FilePath $LogFile;\r\n" +
         "          }\r\n" +
         "        }\r\n" +
         "    }\r\n" +

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -70,17 +70,17 @@ public final class PowershellScript extends FileMonitoringTask {
         String cmd;
         if (capturingOutput) {
             cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;", 
-                c.getPowerShellHelperFile(ws).getRemote(),
-                c.getPowerShellWrapperFile(ws).getRemote(),
-                c.getOutputFile(ws).getRemote(),
-                c.getLogFile(ws).getRemote(),
-                c.getResultFile(ws).getRemote());
+                quote(c.getPowerShellHelperFile(ws)),
+                quote(c.getPowerShellWrapperFile(ws)),
+                quote(c.getOutputFile(ws)),
+                quote(c.getLogFile(ws)),
+                quote(c.getResultFile(ws)));
         } else {
             cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -LogFile '%s' -ResultFile '%s';",
-                c.getPowerShellHelperFile(ws).getRemote(),
-                c.getPowerShellWrapperFile(ws).getRemote(),
-                c.getLogFile(ws).getRemote(),
-                c.getResultFile(ws).getRemote());
+                quote(c.getPowerShellHelperFile(ws)),
+                quote(c.getPowerShellWrapperFile(ws)),
+                quote(c.getLogFile(ws)),
+                quote(c.getResultFile(ws)));
         }
        
         // By default PowerShell adds a byte order mark (BOM) to the beginning of a file when using Out-File with a unicode encoding such as UTF8.
@@ -190,7 +190,7 @@ public final class PowershellScript extends FileMonitoringTask {
                                              "  exit 1;\r\n" +
                                              "} else {\r\n" +
                                              "  exit $LASTEXITCODE;\r\n" + 
-                                             "}", powershellBinary, powershellArgs, c.getPowerShellScriptFile(ws).getRemote());
+                                             "}", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
         
         if (launcher.isUnix()) {
             // There is no need to add a BOM with Open PowerShell
@@ -210,6 +210,10 @@ public final class PowershellScript extends FileMonitoringTask {
         ps.start();
 
         return c;
+    }
+    
+    private static String quote(FilePath f) {
+        return f.getRemote().replace("'", "''");
     }
     
     // In order for PowerShell to properly read a script that contains unicode characters the script should have a BOM, but there is no built in support for

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -93,7 +93,7 @@ public final class PowershellScript extends FileMonitoringTask {
         "  [Parameter(Mandatory=$true)] [System.Text.Encoding] $Encoding\r\n" +
         ")\r\n" +
         "  [string]$FullFilePath = [IO.Path]::GetFullPath( $FilePath );\r\n" +
-        "  [System.IO.StreamWriter]$writer = [System.IO.StreamWriter]::new( $FullFilePath, $true, $Encoding );\r\n" +
+        "  [System.IO.StreamWriter]$writer = New-Object System.IO.StreamWriter( $FullFilePath, $true, $Encoding );\r\n" +
         "  $writer.AutoFlush = $true;\r\n" +
         "  return $writer;\r\n" +
         "}\r\n" +
@@ -120,7 +120,7 @@ public final class PowershellScript extends FileMonitoringTask {
         ")\r\n" +
         "  $exceptionCaught = $null\r\n" +
         "  try {\r\n" +
-        "    [System.Text.Encoding] $encoding = New-Object System.Text.UTF8Encoding $false;\r\n" +
+        "    [System.Text.Encoding] $encoding = New-Object System.Text.UTF8Encoding( $false );\r\n" +
         "    [System.Console]::OutputEncoding = [System.Console]::InputEncoding = $encoding;\r\n" +
         "    [System.IO.Directory]::SetCurrentDirectory( $PWD );\r\n" +
         "    $null = New-Item $LogFile -ItemType File -Force;\r\n" +

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -148,7 +148,7 @@ public final class PowershellScript extends FileMonitoringTask {
         
         if (launcher.isUnix()) {
             // Open-Powershell does not support ExecutionPolicy
-            args.addAll(Arrays.asList("powershell", "-NonInteractive", "-File", quote(c.getPowerShellMainFile(ws))));
+            args.addAll(Arrays.asList("pwsh", "-NonInteractive", "-File", quote(c.getPowerShellMainFile(ws))));
         } else {
             args.addAll(Arrays.asList("powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", quote(c.getPowerShellMainFile(ws))));    
         }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -129,9 +129,9 @@ public final class PowershellScript extends FileMonitoringTask {
         "      if ($CaptureOutput -eq $true) {\r\n" +
         "        $null = New-Item $OutputFile -ItemType File -Force;\r\n" +
         "        [System.IO.StreamWriter]$OutputWriter = New-StreamWriter -FilePath $OutputFile -Encoding $encoding;\r\n" +
-        "        & $MainScript -ErrorAction 'Stop' | Out-FileNoBom -Writer $OutputWriter;\r\n" +
+        "        & $MainScript | Out-FileNoBom -Writer $OutputWriter;\r\n" +
         "      } else {\r\n" +
-        "        & $MainScript -ErrorAction 'Stop';\r\n" +
+        "        & $MainScript;\r\n" +
         "      }\r\n" +
         "    } *>&1 | Out-FileNoBom -Writer $LogWriter;\r\n" +
         "  } catch {\r\n" +
@@ -140,15 +140,13 @@ public final class PowershellScript extends FileMonitoringTask {
         "    $exceptionCaught = $true;\r\n" +
         "  } finally {\r\n" +
         "    $exitCode = 0;\r\n" +
-        "    if ($exceptionCaught -ne $null) {\r\n" +
-        "      $exitCode = 1;\r\n" +
-        "    } elseif ($LastExitCode -ne $null) {\r\n" +
+        "    if ($LastExitCode -ne $null) {\r\n" +
         "      if ($LastExitCode -eq 0 -and !$?) {\r\n" +
         "        $exitCode = 1;\r\n" +
         "      } else {\r\n" +
         "        $exitCode = $LastExitCode;\r\n" +
         "      }\r\n" +
-        "    } elseif (!$?) {\r\n" +
+        "    } elseif ($exceptionCaught -ne $null -or !$?) {\r\n" +
         "      $exitCode = 1;\r\n" +
         "    }\r\n" +
         "    $exitCode | Out-File -FilePath $ResultFile -Encoding ASCII;\r\n" +

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -83,13 +83,12 @@ public final class PowershellScript extends FileMonitoringTask {
                 quote(c.getResultFile(ws)));
         }
       
-        String powershellBinary;
+        // Note: PowerShell core is now named pwsh. Workaround this issue on *nix systems by creating a symlink that maps 'powershell' to 'pwsh'.
+        String powershellBinary = "powershell";
         String powershellArgs;
         if (launcher.isUnix()) {
-            powershellBinary = "pwsh";
             powershellArgs = "-NoProfile -NonInteractive";
         } else {
-            powershellBinary = "powershell.exe";
             powershellArgs = "-NoProfile -NonInteractive -ExecutionPolicy Bypass";
         }
         args.add(powershellBinary);

--- a/src/main/resources/org/jenkinsci/plugins/durabletask/powershellHelper.ps1
+++ b/src/main/resources/org/jenkinsci/plugins/durabletask/powershellHelper.ps1
@@ -1,0 +1,85 @@
+﻿# By default PowerShell adds a byte order mark (BOM) to the beginning of a file when using Out-File with a unicode encoding such as UTF8.
+# This causes the Jenkins output to contain bogus characters because Java does not handle the BOM characters by default.
+# This code mimics Out-File, but does not write a BOM.  Hopefully PowerShell will provide a non-BOM option for writing files in future releases.
+        
+function New-StreamWriter {
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory=$true)] [string] $FilePath,
+  [Parameter(Mandatory=$true)] [System.Text.Encoding] $Encoding
+)
+  [string]$FullFilePath = [IO.Path]::GetFullPath( $FilePath );
+  [System.IO.StreamWriter]$writer = New-Object System.IO.StreamWriter( $FullFilePath, $true, $Encoding );
+  $writer.AutoFlush = $true;
+  return $writer;
+}
+
+function Out-FileNoBom {
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true, Position=0)][AllowNull()] [System.IO.StreamWriter] $Writer,
+  [Parameter(ValueFromPipeline = $true)]                [object] $InputObject
+)
+  Process {
+    if ($Writer) {
+      $Input | Out-String -Stream -Width 192 | ForEach-Object { $Writer.WriteLine( $_ ); }
+    } else {
+      $Input;
+    }
+  }
+}
+
+function Execute-AndWriteOutput {
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)]  [string]$MainScript,
+  [Parameter(Mandatory=$false)] [string]$OutputFile,
+  [Parameter(Mandatory=$true)]  [string]$LogFile,
+  [Parameter(Mandatory=$true)]  [string]$ResultFile,
+  [Parameter(Mandatory=$false)] [switch]$CaptureOutput
+)
+  try {
+    $errorCaught = $null;
+    [System.Text.Encoding] $encoding = New-Object System.Text.UTF8Encoding( $false );
+    [System.Console]::OutputEncoding = [System.Console]::InputEncoding = $encoding;
+    [System.IO.Directory]::SetCurrentDirectory( $PWD );
+    $null = New-Item $LogFile -ItemType File -Force;
+    [System.IO.StreamWriter] $LogWriter = New-StreamWriter -FilePath $LogFile -Encoding $encoding;
+    $OutputWriter = $null;
+    if ($CaptureOutput -eq $true) {
+      $null = New-Item $OutputFile -ItemType File -Force;
+      [System.IO.StreamWriter]$OutputWriter = New-StreamWriter -FilePath $OutputFile -Encoding $encoding;
+    }
+    & { & $MainScript | Out-FileNoBom -Writer $OutputWriter } *>&1 | Out-FileNoBom -Writer $LogWriter;
+  } catch {
+    $errorCaught = $_;
+    $errorCaught | Out-String -Width 192 | Out-FileNoBom -Writer $LogWriter;
+  } finally {
+    $exitCode = 0;
+    if ($LASTEXITCODE -ne $null) {
+      if ($LASTEXITCODE -eq 0 -and $errorCaught -ne $null) {
+        $exitCode = 1;
+      } else {
+        $exitCode = $LASTEXITCODE;
+      }
+    } elseif ($errorCaught -ne $null) {
+      $exitCode = 1;
+    }
+    $exitCode | Out-File -FilePath $ResultFile -Encoding ASCII;
+    if ($CaptureOutput -eq $true -and !(Test-Path $OutputFile)) {
+      $null = New-Item $OutputFile -ItemType File -Force;
+    }
+    if (!(Test-Path $LogFile)) {
+      $null = New-Item $LogFile -ItemType File -Force;
+    }
+    if ($CaptureOutput -eq $true -and $OutputWriter -ne $null) {
+      $OutputWriter.Flush();
+      $OutputWriter.Dispose();
+    }
+    if ($LogWriter -ne $null) {
+      $LogWriter.Flush();
+      $LogWriter.Dispose();
+    }
+    exit $exitCode;
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -135,7 +135,24 @@ public class PowershellScriptTest {
             Thread.sleep(100);
         }
         c.writeLog(ws, tos);
+        String log = baos.toString();
         assertTrue(c.exitStatus(ws, launcher).intValue() != 0);
+        assertTrue(log, log.contains("MyBogus-Cmdlet"));
+        c.cleanup(ws);
+    }
+    
+    @Test public void implicitErrorNegativeTest() throws Exception {
+        Controller c = new PowershellScript("MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        TeeOutputStream tos = new TeeOutputStream(baos, System.err);
+        while (c.exitStatus(ws, launcher) == null) {
+            c.writeLog(ws, tos);
+            Thread.sleep(100);
+        }
+        c.writeLog(ws, tos);
+        String log = baos.toString();
+        assertTrue(c.exitStatus(ws, launcher).intValue() == 0);
+        assertTrue(log, log.contains("MyBogus-Cmdlet"));
         c.cleanup(ws);
     }
     

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -56,7 +56,8 @@ public class PowershellScriptTest {
     private StreamTaskListener listener;
     private FilePath ws;
     private Launcher launcher;
-
+    private int psVersion;
+    
     @Before public void vars() throws IOException, InterruptedException {
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
@@ -86,7 +87,6 @@ public class PowershellScriptTest {
             ps.readStdout();
             Proc proc = ps.start();
             String psVersionStr = IOUtils.toString(proc.getStdout());
-            int psVersion;
             try {
                 psVersion = Integer.parseInt(psVersionStr.trim());
             } catch (NumberFormatException x) {
@@ -179,7 +179,11 @@ public class PowershellScriptTest {
             Thread.sleep(100);
         }
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        assertEquals("VERBOSE: Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
+        if (psVersion >= 5) {
+            assertEquals("VERBOSE: Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
+        } else {
+            assertEquals("Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
+        }
         c.cleanup(ws);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -127,7 +127,7 @@ public class PowershellScriptTest {
     }
     
     @Test public void implicitError() throws Exception {
-        Controller c = new PowershellScript("MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
+        Controller c = new PowershellScript("$ErrorActionPreference = 'Stop'; MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TeeOutputStream tos = new TeeOutputStream(baos, System.err);
         while (c.exitStatus(ws, launcher) == null) {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -150,6 +150,7 @@ public class PowershellScriptTest {
         c.writeLog(ws, baos);
         assertTrue(c.exitStatus(ws, launcher).intValue() != 0);
         assertThat(baos.toString(), containsString("explicit error"));
+        assertEquals("Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
         c.cleanup(ws);
     }
     
@@ -160,10 +161,8 @@ public class PowershellScriptTest {
         while (c.exitStatus(ws, launcher) == null) {
             Thread.sleep(100);
         }
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        assertThat(baos.toString(), containsString("Hello, World!"));
+        assertEquals("VERBOSE: Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
         c.cleanup(ws);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -98,61 +98,46 @@ public class PowershellScriptTest {
 
     @Test public void explicitExit() throws Exception {
         Controller c = new PowershellScript("Write-Output \"Hello, World!\"; exit 1;").launch(new EnvVars(), ws, launcher, listener);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        TeeOutputStream tos = new TeeOutputStream(baos, System.err);
         while (c.exitStatus(ws, launcher) == null) {
-            c.writeLog(ws, tos);
             Thread.sleep(100);
         }
-        c.writeLog(ws, tos);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
         assertEquals(Integer.valueOf(1), c.exitStatus(ws, launcher));
-        String log = baos.toString();
-        assertTrue(log, log.contains("Hello, World!"));
+        assertThat(baos.toString(), containsString("Hello, World!"));
         c.cleanup(ws);
     }
     
     @Test public void implicitExit() throws Exception {
         Controller c = new PowershellScript("Write-Output \"Success!\";").launch(new EnvVars(), ws, launcher, listener);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        TeeOutputStream tos = new TeeOutputStream(baos, System.err);
         while (c.exitStatus(ws, launcher) == null) {
-            c.writeLog(ws, tos);
             Thread.sleep(100);
         }
-        c.writeLog(ws, tos);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
         assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher));
-        String log = baos.toString();
-        assertTrue(log, log.contains("Success!"));
+        assertThat(baos.toString(), containsString("Success!"));
         c.cleanup(ws);
     }
     
     @Test public void implicitError() throws Exception {
-        Controller c = new PowershellScript("$ErrorActionPreference = 'Stop'; MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        TeeOutputStream tos = new TeeOutputStream(baos, System.err);
+        Controller c = new PowershellScript("MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
         while (c.exitStatus(ws, launcher) == null) {
-            c.writeLog(ws, tos);
             Thread.sleep(100);
         }
-        c.writeLog(ws, tos);
-        String log = baos.toString();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
         assertTrue(c.exitStatus(ws, launcher).intValue() != 0);
-        assertTrue(log, log.contains("MyBogus-Cmdlet"));
+        assertThat(baos.toString(), containsString("MyBogus-Cmdlet"));
         c.cleanup(ws);
     }
     
     @Test public void implicitErrorNegativeTest() throws Exception {
-        Controller c = new PowershellScript("MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        TeeOutputStream tos = new TeeOutputStream(baos, System.err);
+        Controller c = new PowershellScript("$ErrorActionPreference = 'SilentlyContinue'; MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
         while (c.exitStatus(ws, launcher) == null) {
-            c.writeLog(ws, tos);
             Thread.sleep(100);
         }
-        c.writeLog(ws, tos);
-        String log = baos.toString();
         assertTrue(c.exitStatus(ws, launcher).intValue() == 0);
-        assertTrue(log, log.contains("MyBogus-Cmdlet"));
         c.cleanup(ws);
     }
     
@@ -179,11 +164,7 @@ public class PowershellScriptTest {
             Thread.sleep(100);
         }
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        if (psVersion >= 5) {
-            assertEquals("VERBOSE: Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
-        } else {
-            assertEquals("Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
-        }
+        assertEquals("VERBOSE: Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
         c.cleanup(ws);
     }
 
@@ -211,13 +192,11 @@ public class PowershellScriptTest {
     
     @Test public void unicodeChars() throws Exception {
         Controller c = new PowershellScript("Write-Output \"Helló, Wõrld ®\";").launch(new EnvVars(), ws, launcher, listener);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        TeeOutputStream tos = new TeeOutputStream(baos, System.err);
         while (c.exitStatus(ws, launcher) == null) {
-            c.writeLog(ws, tos);
             Thread.sleep(100);
         }
-        c.writeLog(ws, tos);
+       ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
         assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher));
         String log = baos.toString("UTF-8");
         assertTrue(log, log.contains("Helló, Wõrld ®"));

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -169,14 +169,10 @@ public class PowershellScriptTest {
 
     @Test public void spacesInWorkspace() throws Exception {
         final FilePath newWs = new FilePath(ws, "subdirectory with spaces");
-        DurableTask task = new PowershellScript("Write-Host 'Running in a workspace with spaces in the path'");
-        task.captureOutput();
-        Controller c = task.launch(new EnvVars(), newWs, launcher, listener);
+        Controller c = new PowershellScript("Write-Host 'Running in a workspace with spaces in the path'").launch(new EnvVars(), newWs, launcher, listener);
         while (c.exitStatus(newWs, launcher) == null) {
             Thread.sleep(100);
         }
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        c.writeLog(newWs, baos);
         assertEquals(0, c.exitStatus(newWs, launcher).intValue());
         c.cleanup(ws);
     }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -65,7 +65,7 @@ public class PowershellScriptTest {
         String pathSeparator = properties.getProperty("path.separator");
         String[] paths = System.getenv("PATH").split(pathSeparator);
         boolean powershellExists = false;
-        String cmd = launcher.isUnix()?"powershell":"powershell.exe";
+        String cmd = launcher.isUnix()?"pwsh":"powershell.exe";
         for (String p : paths) {
             File f = new File(p, cmd);
             if (f.exists()) {
@@ -81,7 +81,7 @@ public class PowershellScriptTest {
             if (!launcher.isUnix()) {
                 args.addAll(Arrays.asList("-ExecutionPolicy", "Bypass"));
             }
-            args.add("$PSVersionTable.PSVersion.Major");
+            args.addAll(Arrays.asList("-Command", "& {Write-Output $PSVersionTable.PSVersion.Major}"));
             Launcher.ProcStarter ps = launcher.launch().cmds(args).quiet(true);
             ps.readStdout();
             Proc proc = ps.start();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -66,10 +66,13 @@ public class PowershellScriptTest {
         String pathSeparator = properties.getProperty("path.separator");
         String[] paths = System.getenv("PATH").split(pathSeparator);
         boolean powershellExists = false;
-        String cmd = launcher.isUnix()?"pwsh":"powershell.exe";
+        // Note: This prevents this set of tests from running on PowerShell core unless a symlink is created that maps 'powershell' to 'pwsh' on *nix systems
+        String cmd = "powershell";
         for (String p : paths) {
-            File f = new File(p, cmd);
-            if (f.exists()) {
+            // If running on *nix then the binary does not have an extension.  Check for both variants to ensure *nix and windows+cygwin are both supported.
+            File withoutExtension = new File(p, cmd);
+            File withExtension = new File(p, cmd + ".exe");
+            if (withoutExtension.exists() || withExtension.exists()) {
                 powershellExists = true;
                 break;
             }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -167,6 +167,20 @@ public class PowershellScriptTest {
         c.cleanup(ws);
     }
 
+    @Test public void spacesInWorkspace() throws Exception {
+        final FilePath newWs = new FilePath(ws, "subdirectory with spaces");
+        DurableTask task = new PowershellScript("Write-Host 'Running in a workspace with spaces in the path'");
+        task.captureOutput();
+        Controller c = task.launch(new EnvVars(), newWs, launcher, listener);
+        while (c.exitStatus(newWs, launcher) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(newWs, baos);
+        assertEquals(0, c.exitStatus(newWs, launcher).intValue());
+        c.cleanup(ws);
+    }
+
     @Test public void echoEnvVar() throws Exception {
         Controller c = new PowershellScript("echo envvar=$env:MYVAR").launch(new EnvVars("MYVAR", "power$hell"), ws, launcher, listener);
         while (c.exitStatus(ws, launcher) == null) {


### PR DESCRIPTION
Fixing several issues with powershell hanging and incorrect handling of exit codes

[JENKINS-46876](https://issues.jenkins-ci.org/browse/JENKINS-46876) [JENKINS-46508](https://issues.jenkins-ci.org/browse/JENKINS-46508)  [JENKINS-46496](https://issues.jenkins-ci.org/browse/JENKINS-46496)  [JENKINS-48057](https://issues.jenkins-ci.org/browse/JENKINS-48057)  [JENKINS-47797 ](https://issues.jenkins-ci.org/browse/JENKINS-47797 ) 