### PR TITLE
Specify java.level=7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     
     <properties>
       <jenkins.version>2.7.3</jenkins.version>
+      <java.level>7</java.level>
       <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
     


### PR DESCRIPTION
#49 inadvertently switched the plugin to use Java 8 despite a baseline of 2.7.x, due to a decision in https://github.com/jenkinsci/plugin-pom/pull/83 which I think was dangerous.

@reviewbybees