### PR TITLE
[Fixed JENKINS-48803] Updating PowerShell executable name on linux

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -143,7 +143,7 @@ public final class PowershellScript extends FileMonitoringTask {
 
         if (launcher.isUnix()) {
             // Open-Powershell does not support ExecutionPolicy
-            args.addAll(Arrays.asList("powershell", "-NonInteractive", "-Command", cmd));
+            args.addAll(Arrays.asList("pwsh", "-NonInteractive", "-Command", cmd));
         } else {
             args.addAll(Arrays.asList("powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", cmd));    
         }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -65,7 +65,7 @@ public class PowershellScriptTest {
         String pathSeparator = properties.getProperty("path.separator");
         String[] paths = System.getenv("PATH").split(pathSeparator);
         boolean powershellExists = false;
-        String cmd = launcher.isUnix()?"powershell":"powershell.exe";
+        String cmd = launcher.isUnix()?"pwsh":"powershell.exe";
         for (String p : paths) {
             File f = new File(p, cmd);
             if (f.exists()) {


### PR DESCRIPTION
The reasoning is really stupid and I certainly hope they setup an alias in a future release but powershell is now pwsh, this is in the latest RC and is part of the GA release for powershell next week. Given all previous releases of Powershell for Linux were pre-release I propose that detecting which executable name to use should not be required; if the durable task plugin is updated then so too should powershell (alternatively they can manually alias the command until a Powershell update is applied).