### PR TITLE
[JENKINS-48300] Add an overload for exitStatus taking TaskListener

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/Controller.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/Controller.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.durabletask;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.model.TaskListener;
 import hudson.util.LogTaskListener;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -55,17 +56,27 @@ public abstract class Controller implements Serializable {
      * Checks whether the task has finished.
      * @param workspace the workspace in use
      * @param launcher a way to start processes
+     * @param logger a way to report special messages
      * @return an exit code (zero is successful), or null if the task appears to still be running
      */
-    public @CheckForNull Integer exitStatus(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
-        if (Util.isOverridden(Controller.class, getClass(), "exitStatus", FilePath.class)) {
+    public @CheckForNull Integer exitStatus(FilePath workspace, Launcher launcher, TaskListener logger) throws IOException, InterruptedException {
+        if (Util.isOverridden(Controller.class, getClass(), "exitStatus", FilePath.class, Launcher.class)) {
+            return exitStatus(workspace, launcher);
+        } else if (Util.isOverridden(Controller.class, getClass(), "exitStatus", FilePath.class)) {
             return exitStatus(workspace);
         } else {
-            throw new AbstractMethodError("implement exitStatus(FilePath, Launcher)");
+            throw new AbstractMethodError("implement exitStatus(FilePath, Launcher, TaskListener)");
         }
     }
 
-    /** @deprecated use {@link #exitStatus(FilePath, Launcher)} instead */
+    /** @deprecated use {@link #exitStatus(FilePath, Launcher, TaskListener)} instead */
+    @Deprecated
+    public @CheckForNull Integer exitStatus(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
+        return exitStatus(workspace, launcher, TaskListener.NULL);
+    }
+
+    /** @deprecated use {@link #exitStatus(FilePath, Launcher, TaskListener)} instead */
+    @Deprecated
     public @CheckForNull Integer exitStatus(FilePath workspace) throws IOException, InterruptedException {
         return exitStatus(workspace, createLauncher(workspace));
     }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -100,12 +100,12 @@ public class PowershellScriptTest {
         Controller c = new PowershellScript("Write-Output \"Hello, World!\"; exit 1;").launch(new EnvVars(), ws, launcher, listener);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TeeOutputStream tos = new TeeOutputStream(baos, System.err);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             c.writeLog(ws, tos);
             Thread.sleep(100);
         }
         c.writeLog(ws, tos);
-        assertEquals(Integer.valueOf(1), c.exitStatus(ws, launcher));
+        assertEquals(Integer.valueOf(1), c.exitStatus(ws, launcher, listener));
         String log = baos.toString();
         assertTrue(log, log.contains("Hello, World!"));
         c.cleanup(ws);
@@ -115,12 +115,12 @@ public class PowershellScriptTest {
         Controller c = new PowershellScript("Write-Output \"Success!\";").launch(new EnvVars(), ws, launcher, listener);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TeeOutputStream tos = new TeeOutputStream(baos, System.err);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             c.writeLog(ws, tos);
             Thread.sleep(100);
         }
         c.writeLog(ws, tos);
-        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher));
+        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher, listener));
         String log = baos.toString();
         assertTrue(log, log.contains("Success!"));
         c.cleanup(ws);
@@ -130,12 +130,12 @@ public class PowershellScriptTest {
         Controller c = new PowershellScript("MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TeeOutputStream tos = new TeeOutputStream(baos, System.err);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             c.writeLog(ws, tos);
             Thread.sleep(100);
         }
         c.writeLog(ws, tos);
-        assertTrue(c.exitStatus(ws, launcher).intValue() != 0);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
         c.cleanup(ws);
     }
     
@@ -143,12 +143,12 @@ public class PowershellScriptTest {
         DurableTask task = new PowershellScript("Write-Output \"Hello, World!\"; throw \"explicit error\";");
         task.captureOutput();
         Controller c = task.launch(new EnvVars(), ws, launcher, listener);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
-        assertTrue(c.exitStatus(ws, launcher).intValue() != 0);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
         assertThat(baos.toString(), containsString("explicit error"));
         c.cleanup(ws);
     }
@@ -157,24 +157,24 @@ public class PowershellScriptTest {
         DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; Write-Verbose \"Hello, World!\"");
         task.captureOutput();
         Controller c = task.launch(new EnvVars(), ws, launcher, listener);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
-        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
         assertThat(baos.toString(), containsString("Hello, World!"));
         c.cleanup(ws);
     }
 
     @Test public void echoEnvVar() throws Exception {
         Controller c = new PowershellScript("echo envvar=$env:MYVAR").launch(new EnvVars("MYVAR", "power$hell"), ws, launcher, listener);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws,baos);
-        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
         assertThat(baos.toString(), containsString("envvar=power$hell"));
         c.cleanup(ws);
     }
@@ -183,12 +183,12 @@ public class PowershellScriptTest {
         Controller c = new PowershellScript("Write-Output \"Helló, Wõrld ®\";").launch(new EnvVars(), ws, launcher, listener);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TeeOutputStream tos = new TeeOutputStream(baos, System.err);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             c.writeLog(ws, tos);
             Thread.sleep(100);
         }
         c.writeLog(ws, tos);
-        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher));
+        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher, listener));
         String log = baos.toString("UTF-8");
         assertTrue(log, log.contains("Helló, Wõrld ®"));
         c.cleanup(ws);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -76,12 +76,12 @@ public class WindowsBatchScriptTest {
 
     private void testWithPath(String path) throws Exception {
         Controller c = new WindowsBatchScript("echo hello world").launch(new EnvVars(), ws, launcher, listener);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
-        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher));
+        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher, listener));
         String log = baos.toString();
         System.err.print(log);
         assertTrue(log, log.contains("hello world"));
@@ -93,12 +93,12 @@ public class WindowsBatchScriptTest {
         Controller c = new WindowsBatchScript("echo hello world\r\nexit 1").launch(new EnvVars(), ws, launcher, listener);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TeeOutputStream tos = new TeeOutputStream(baos, System.err);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             c.writeLog(ws, tos);
             Thread.sleep(100);
         }
         c.writeLog(ws, tos);
-        assertEquals(Integer.valueOf(1), c.exitStatus(ws, launcher));
+        assertEquals(Integer.valueOf(1), c.exitStatus(ws, launcher, listener));
         String log = baos.toString();
         assertTrue(log, log.contains("hello world"));
         c.cleanup(ws);
@@ -109,12 +109,12 @@ public class WindowsBatchScriptTest {
         DurableTask task = new WindowsBatchScript("@echo 42"); // http://stackoverflow.com/a/8486061/12916
         task.captureOutput();
         Controller c = task.launch(new EnvVars(), ws, launcher, listener);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
-        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
         assertEquals("42\r\n", new String(c.getOutput(ws, launcher)));
         c.cleanup(ws);
     }
@@ -122,12 +122,12 @@ public class WindowsBatchScriptTest {
     @Issue("JENKINS-40734")
     @Test public void envWithShellChar() throws Exception {
         Controller c = new WindowsBatchScript("echo value=%MYNEWVAR%").launch(new EnvVars("MYNEWVAR", "foo$$bar"), ws, launcher, listener);
-        while (c.exitStatus(ws, launcher) == null) {
+        while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws,baos);
-        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
         assertThat(baos.toString(), containsString("value=foo$$bar"));
         c.cleanup(ws);
     }


### PR DESCRIPTION
See discussion in [JENKINS-48300](https://issues.jenkins-ci.org/browse/JENKINS-48300). If we are going to return -1 (or -2) from `sh`, rather than an actual code, at least print some explanatory message.

@reviewbybees