### PR TITLE
[JENKINS-52165] Controller.watch API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>durable-task</artifactId>
-    <version>1.17</version>
+    <version>1.18-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Durable Task Plugin</name>
     <description>Library offering an extension point for processes which can run outside of Jenkins yet be monitored.</description>
@@ -42,7 +42,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>durable-task-1.17</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>durable-task</artifactId>
-    <version>1.17-SNAPSHOT</version>
+    <version>1.17</version>
     <packaging>hpi</packaging>
     <name>Durable Task Plugin</name>
     <description>Library offering an extension point for processes which can run outside of Jenkins yet be monitored.</description>
@@ -42,7 +42,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>HEAD</tag>
+        <tag>durable-task-1.17</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -207,8 +207,8 @@ public final class BourneShellScript extends FileMonitoringTask {
             return controlDir(ws).child("pid");
         }
 
-        @Override public Integer exitStatus(FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
-            Integer status = super.exitStatus(workspace, launcher, listener);
+        @Override protected Integer exitStatus(FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
+            Integer status = super.exitStatus(workspace, listener);
             if (status != null) {
                 LOGGER.log(Level.FINE, "found exit code {0} in {1}", new Object[] {status, controlDir});
                 return status;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/Controller.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/Controller.java
@@ -44,6 +44,20 @@ import javax.annotation.Nonnull;
 public abstract class Controller implements Serializable {
 
     /**
+     * Begins watching the process asynchronously, so that the master may receive notification when output is available or the process has exited.
+     * This should be called as soon as the process is launched, and thereafter whenever reconnecting to the agent.
+     * You should not call {@link #writeLog} or {@link #cleanup} in this case; you do not need to call {@link #exitStatus(FilePath, Launcher)} frequently,
+     * though it is advisable to still call it occasionally to verify that the process is still running.
+     * @param workspace the workspace in use
+     * @param handler a remotable callback
+     * @param listener a remotable destination for messages
+     * @throws UnsupportedOperationException when this mode is not available, so you must fall back to polling {@link #writeLog} and {@link #exitStatus(FilePath, Launcher)}
+     */
+    public void watch(@Nonnull FilePath workspace, @Nonnull Handler handler, @Nonnull TaskListener listener) throws IOException, InterruptedException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Asynchronous mode is not implemented in " + getClass().getName());
+    }
+
+    /**
      * Obtains any new task log output.
      * Could use a serializable field to keep track of how much output has been previously written.
      * @param workspace the workspace in use
@@ -55,7 +69,7 @@ public abstract class Controller implements Serializable {
     /**
      * Checks whether the task has finished.
      * @param workspace the workspace in use
-     * @param launcher a way to start processes
+     * @param launcher a way to start processes (currently unused)
      * @param logger a way to report special messages
      * @return an exit code (zero is successful), or null if the task appears to still be running
      */
@@ -86,7 +100,7 @@ public abstract class Controller implements Serializable {
      * Intended for use after {@link #exitStatus(FilePath, Launcher)} has returned a non-null status.
      * The result is undefined if {@link DurableTask#captureOutput} was not called before launch; generally an {@link IOException} will result.
      * @param workspace the workspace in use
-     * @param launcher a way to start processes
+     * @param launcher a way to start processes (currently unused)
      * @return the output of the process as raw bytes (may be empty but not null)
      */
     public @Nonnull byte[] getOutput(@Nonnull FilePath workspace, @Nonnull Launcher launcher) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/DurableTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/DurableTask.java
@@ -53,8 +53,9 @@ public abstract class DurableTask extends AbstractDescribableImpl<DurableTask> i
     public abstract Controller launch(EnvVars env, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException;
 
     /**
-     * Requests that standard output of the task be captured rather than streamed to {@link Controller#writeLog}.
-     * If so, you may call {@link Controller#getOutput}.
+     * Requests that standard output of the task be captured rather than streamed.
+     * If you use {@link Controller#watch}, standard output will not be sent to {@link Handler#output}; it will be included in {@link Handler#exited} instead.
+     * Otherwise (using polling mode), standard output will not be sent to {@link Controller#writeLog}; call {@link Controller#getOutput} to collect.
      * Standard error should still be streamed to the log.
      * Should be called prior to {@link #launch} to take effect.
      * @throws UnsupportedOperationException if this implementation does not support that mode

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -293,6 +293,7 @@ public abstract class FileMonitoringTask extends DurableTask {
     private static ScheduledExecutorService watchService;
     private synchronized static ScheduledExecutorService watchService() {
         if (watchService == null) {
+            // TODO 2.105+ use ClassLoaderSanityThreadFactory
             watchService = new /*ErrorLogging*/ScheduledThreadPoolExecutor(5, new NamingThreadFactory(new DaemonThreadFactory(), "FileMonitoringTask watcher"));
         }
         return watchService;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -142,7 +142,7 @@ public abstract class FileMonitoringTask extends DurableTask {
      * Tails a log file and watches for an exit status file.
      * Must be remotable so that {@link #watch} can transfer the implementation.
      */
-    protected static class FileMonitoringController extends Controller {
+    protected static class FileMonitoringController extends Controller { // TODO implements Remotable when available (*not* SerializableOnlyOverRemoting)
 
         /** Absolute path of {@link #controlDir(FilePath)}. */
         String controlDir;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -476,8 +476,11 @@ public abstract class FileMonitoringTask extends DurableTask {
                         InputStream locallyEncodedStream = Channels.newInputStream(ch.position(lastLocation));
                         CountingInputStream cis = new CountingInputStream(locallyEncodedStream);
                         InputStream utf8EncodedStream = cs == null ? cis : new ReaderInputStream(new InputStreamReader(cis, cs), StandardCharsets.UTF_8);
-                        handler.output(utf8EncodedStream);
-                        lastLocationFile.write(Long.toString(lastLocation + cis.getByteCount()), null);
+                        try {
+                            handler.output(utf8EncodedStream);
+                        } finally {
+                            lastLocationFile.write(Long.toString(lastLocation + cis.getByteCount()), null);
+                        }
                     }
                 }
                 if (exitStatus != null) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -474,11 +474,8 @@ public abstract class FileMonitoringTask extends DurableTask {
                     try (FileChannel ch = FileChannel.open(Paths.get(logFile.getRemote()), StandardOpenOption.READ)) {
                         InputStream locallyEncodedStream = Channels.newInputStream(ch.position(lastLocation));
                         InputStream utf8EncodedStream = cs == null ? locallyEncodedStream : new ReaderInputStream(new InputStreamReader(locallyEncodedStream, cs), StandardCharsets.UTF_8);
-                        try {
-                            handler.output(utf8EncodedStream);
-                        } finally {
-                            lastLocationFile.write(Long.toString(ch.position()), null);
-                        }
+                        handler.output(utf8EncodedStream);
+                        lastLocationFile.write(Long.toString(ch.position()), null);
                     }
                 }
                 if (exitStatus != null) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -474,9 +474,9 @@ public abstract class FileMonitoringTask extends DurableTask {
                     assert !logFile.isRemote();
                     try (FileChannel ch = FileChannel.open(Paths.get(logFile.getRemote()), StandardOpenOption.READ)) {
                         InputStream locallyEncodedStream = Channels.newInputStream(ch.position(lastLocation));
-                        InputStream utf8EncodedStream = cs == null ? locallyEncodedStream : new ReaderInputStream(new InputStreamReader(locallyEncodedStream, cs), StandardCharsets.UTF_8);
-                        CountingInputStream cis = new CountingInputStream(utf8EncodedStream);
-                        handler.output(cis);
+                        CountingInputStream cis = new CountingInputStream(locallyEncodedStream);
+                        InputStream utf8EncodedStream = cs == null ? cis : new ReaderInputStream(new InputStreamReader(cis, cs), StandardCharsets.UTF_8);
+                        handler.output(utf8EncodedStream);
                         lastLocationFile.write(Long.toString(lastLocation + cis.getByteCount()), null);
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -30,6 +30,8 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
+import hudson.remoting.DaemonThreadFactory;
+import hudson.remoting.NamingThreadFactory;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.WorkspaceList;
@@ -39,15 +41,23 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.CountingInputStream;
 
 /**
  * A task which forks some external command and then waits for log and status files to be updated/created.
@@ -95,6 +105,10 @@ public abstract class FileMonitoringTask extends DurableTask {
         return m;
     }
 
+    /**
+     * Tails a log file and watches for an exit status file.
+     * Must be remotable so that {@link #watch} can transfer the implementation.
+     */
     protected static class FileMonitoringController extends Controller {
 
         /** Absolute path of {@link #controlDir(FilePath)}. */
@@ -107,6 +121,7 @@ public abstract class FileMonitoringTask extends DurableTask {
 
         /**
          * Byte offset in the file that has been reported thus far.
+         * Only used if {@link #writeLog(FilePath, OutputStream)} is used; not used for {@link #watch}.
          */
         private long lastLocation;
 
@@ -146,7 +161,6 @@ public abstract class FileMonitoringTask extends DurableTask {
                         if (toRead > Integer.MAX_VALUE) { // >2Gb of output at once is unlikely
                             throw new IOException("large reads not yet implemented");
                         }
-                        // TODO is this efficient for large amounts of output? Would it be better to stream data, or return a byte[] from the callable?
                         byte[] buf = new byte[(int) toRead];
                         raf.readFully(buf);
                         sink.write(buf);
@@ -160,8 +174,14 @@ public abstract class FileMonitoringTask extends DurableTask {
             }
         }
 
-        // TODO would be more efficient to allow API to consolidate writeLog with exitStatus (save an RPC call)
         @Override public Integer exitStatus(FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+            return exitStatus(workspace, listener);
+        }
+
+        /**
+         * Like {@link #exitStatus(FilePath, Launcher, TaskListener)} but not requesting a {@link Launcher}, which would not be available in {@link #watch} mode anyway.
+         */
+        protected Integer exitStatus(FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
             FilePath status = getResultFile(workspace);
             if (status.exists()) {
                 try {
@@ -175,7 +195,13 @@ public abstract class FileMonitoringTask extends DurableTask {
         }
 
         @Override public byte[] getOutput(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
-            // TODO could perhaps be more efficient for large files to send a MasterToSlaveFileCallable<byte[]>
+            return getOutput(workspace);
+        }
+
+        /**
+         * Like {@link #getOutput(FilePath, Launcher)} but not requesting a {@link Launcher}, which would not be available in {@link #watch} mode anyway.
+         */
+        protected byte[] getOutput(FilePath workspace) throws IOException, InterruptedException {
             try (InputStream is = getOutputFile(workspace).read()) {
                 return IOUtils.toByteArray(is);
             }
@@ -183,6 +209,7 @@ public abstract class FileMonitoringTask extends DurableTask {
 
         @Override public final void stop(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
             launcher.kill(Collections.singletonMap(COOKIE, cookieFor(workspace)));
+            // TODO after 10s, if the control dir still exists, write a flag file and have the Watcher shut down (interrupting any ongoing handler.output call if possible)
         }
 
         @Override public void cleanup(FilePath workspace) throws IOException, InterruptedException {
@@ -248,7 +275,102 @@ public abstract class FileMonitoringTask extends DurableTask {
             }
         }
 
+        @Override public void watch(FilePath workspace, Handler handler, TaskListener listener) throws IOException, InterruptedException, ClassCastException {
+            workspace.actAsync(new StartWatching(this, handler, listener));
+            LOGGER.log(Level.FINE, "started asynchronous watch in {0}", controlDir);
+        }
+
+        /**
+         * File in which a last-read position is stored if {@link #watch} is used.
+         */
+        public FilePath getLastLocationFile(FilePath workspace) throws IOException, InterruptedException {
+            return controlDir(workspace).child("last-location.txt");
+        }
+
         private static final long serialVersionUID = 1L;
+    }
+
+    private static ScheduledExecutorService watchService;
+    private synchronized static ScheduledExecutorService watchService() {
+        if (watchService == null) {
+            watchService = new /*ErrorLogging*/ScheduledThreadPoolExecutor(5, new NamingThreadFactory(new DaemonThreadFactory(), "FileMonitoringTask watcher"));
+        }
+        return watchService;
+    }
+
+    private static class StartWatching extends MasterToSlaveFileCallable<Void> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final FileMonitoringController controller;
+        private final Handler handler;
+        private final TaskListener listener;
+
+        StartWatching(FileMonitoringController controller, Handler handler, TaskListener listener) {
+            this.controller = controller;
+            this.handler = handler;
+            this.listener = listener;
+        }
+
+        @Override public Void invoke(File workspace, VirtualChannel channel) throws IOException, InterruptedException {
+            watchService().submit(new Watcher(controller, new FilePath(workspace), handler, listener));
+            return null;
+        }
+
+    }
+
+    private static class Watcher implements Runnable {
+
+        private final FileMonitoringController controller;
+        private final FilePath workspace;
+        private final Handler handler;
+        private final TaskListener listener;
+
+        Watcher(FileMonitoringController controller, FilePath workspace, Handler handler, TaskListener listener) {
+            this.controller = controller;
+            this.workspace = workspace;
+            this.handler = handler;
+            this.listener = listener;
+        }
+
+        @Override public void run() {
+            try {
+                Integer exitStatus = controller.exitStatus(workspace, listener); // check before collecting output, in case the process is just now finishing
+                long lastLocation = 0;
+                FilePath lastLocationFile = controller.getLastLocationFile(workspace);
+                if (lastLocationFile.exists()) {
+                    lastLocation = Long.parseLong(lastLocationFile.readToString());
+                }
+                FilePath logFile = controller.getLogFile(workspace);
+                long len = logFile.length();
+                if (len > lastLocation) {
+                    assert !logFile.isRemote();
+                    try (FileChannel ch = FileChannel.open(Paths.get(logFile.getRemote()), StandardOpenOption.READ)) {
+                        CountingInputStream cis = new CountingInputStream(Channels.newInputStream(ch.position(lastLocation)));
+                        handler.output(cis);
+                        lastLocationFile.write(Long.toString(lastLocation + cis.getByteCount()), null);
+                    }
+                }
+                if (exitStatus != null) {
+                    byte[] output;
+                    if (controller.getOutputFile(workspace).exists()) {
+                        output = controller.getOutput(workspace);
+                    } else {
+                        output = null;
+                    }
+                    handler.exited(exitStatus, output);
+                    controller.cleanup(workspace);
+                } else {
+                    // Could use an adaptive timeout as in DurableTaskStep.Execution in polling mode,
+                    // though less relevant here since there is no network overhead to the check.
+                    watchService().schedule(this, 100, TimeUnit.MILLISECONDS);
+                }
+            } catch (Exception x) {
+                // note that LOGGER here is going to the agent log, not master log
+                LOGGER.log(Level.WARNING, "giving up on watching " + controller.controlDir, x);
+            }
+        }
+
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/Handler.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/Handler.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.durabletask;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.remoting.VirtualChannel;
+import java.io.InputStream;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A remote handler which may be sent to an agent and handle process output and results.
+ * If it needs to communicate with the master, you may use {@link VirtualChannel#export}.
+ * @see Controller#watch
+ */
+public abstract class Handler implements Serializable {
+
+    /**
+     * Notification that new process output is available.
+     * <p>Should only be called when at least one byte is available.
+     * Whatever bytes are actually read will not be offered on the next call, if there is one; there is no need to close the stream.
+     * <p>There is no guarantee that output is offered in the form of complete lines of text,
+     * though in the typical case of line-oriented output it is likely that it will end in a newline.
+     * <p>Buffering is the responsibility of the caller, and {@link InputStream#markSupported} may be false.
+     * @param stream a way to read process output which has not already been handled
+     * @throws Exception if anything goes wrong, this watch is deactivated
+     */
+    public abstract void output(@Nonnull InputStream stream) throws Exception;
+
+    /**
+     * Notification that the process has exited or vanished.
+     * {@link #output} should have been called with any final uncollected output.
+     * <p>Any metadata associated with the process may be deleted after this call completes, rendering subsequent {@link Controller} calls unsatisfiable.
+     * <p>Note that unlike {@link Controller#exitStatus(FilePath, Launcher)}, no specialized {@link Launcher} is available on the agent,
+     * so if there are specialized techniques for determining process liveness they will not be considered here;
+     * you still need to occasionally poll for an exit status from the master.
+     * @param code the exit code, if known (0 conventionally represents success); may be negative for anomalous conditions such as a missing process
+     * @param output standard output captured, if {@link DurableTask#captureOutput} was called; else null
+     * @throws Exception if anything goes wrong, this watch is deactivated
+     */
+    public abstract void exited(int code, @Nullable byte[] output) throws Exception;
+
+}

--- a/src/main/java/org/jenkinsci/plugins/durabletask/Handler.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/Handler.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
  * If it needs to communicate with the master, you may use {@link VirtualChannel#export}.
  * @see Controller#watch
  */
-public abstract class Handler implements Serializable {
+public abstract class Handler implements Serializable { // TODO 2.107+ SerializableOnlyOverRemoting
 
     /**
      * Notification that new process output is available.

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -469,7 +469,56 @@ public class BourneShellScriptTest {
         assertEquals(0, status.take().intValue());
         assertEquals("Čau!", output.take());
         assertEquals("[]", lines.toString());
-        // TODO agent default; mojibake
+        // with agent default charset:
+        dt = new BourneShellScript("cat latin");
+        dt.defaultCharset();
+        c = dt.launch(new EnvVars(), dockerWS, dockerLauncher, listener);
+        status = new LinkedBlockingQueue<>();
+        output = new LinkedBlockingQueue<>();
+        lines = new LinkedBlockingQueue<>();
+        c.watch(dockerWS, new MockHandler(s.getChannel(), status, output, lines), listener);
+        assertEquals("+ cat latin", lines.take());
+        assertEquals(0, status.take().intValue());
+        assertEquals("<no output>", output.take());
+        assertEquals("[¡Ole!]", lines.toString());
+        // and with output capture:
+        dt = new BourneShellScript("cat latin");
+        dt.defaultCharset();
+        dt.captureOutput();
+        c = dt.launch(new EnvVars(), dockerWS, dockerLauncher, listener);
+        status = new LinkedBlockingQueue<>();
+        output = new LinkedBlockingQueue<>();
+        lines = new LinkedBlockingQueue<>();
+        c.watch(dockerWS, new MockHandler(s.getChannel(), status, output, lines), listener);
+        assertEquals("+ cat latin", lines.take());
+        assertEquals(0, status.take().intValue());
+        assertEquals("¡Ole!", output.take());
+        assertEquals("[]", lines.toString());
+        // and mojibake:
+        dt = new BourneShellScript("cat mixed");
+        dt.charset(StandardCharsets.US_ASCII);
+        c = dt.launch(new EnvVars(), dockerWS, dockerLauncher, listener);
+        status = new LinkedBlockingQueue<>();
+        output = new LinkedBlockingQueue<>();
+        lines = new LinkedBlockingQueue<>();
+        c.watch(dockerWS, new MockHandler(s.getChannel(), status, output, lines), listener);
+        assertEquals("+ cat mixed", lines.take());
+        assertEquals(0, status.take().intValue());
+        assertEquals("<no output>", output.take());
+        assertEquals("[����au ��� there!]", lines.toString());
+        // and with output capture:
+        dt = new BourneShellScript("cat mixed");
+        dt.charset(StandardCharsets.US_ASCII);
+        dt.captureOutput();
+        c = dt.launch(new EnvVars(), dockerWS, dockerLauncher, listener);
+        status = new LinkedBlockingQueue<>();
+        output = new LinkedBlockingQueue<>();
+        lines = new LinkedBlockingQueue<>();
+        c.watch(dockerWS, new MockHandler(s.getChannel(), status, output, lines), listener);
+        assertEquals("+ cat mixed", lines.take());
+        assertEquals(0, status.take().intValue());
+        assertEquals("����au ��� there!", output.take());
+        assertEquals("[]", lines.toString());
         s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
     }
     private static class DetectCharset extends MasterToSlaveCallable<String, RuntimeException> {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -37,15 +37,11 @@ import hudson.util.VersionNumber;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
-import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.TeeOutputStream;
 import static org.hamcrest.Matchers.*;
@@ -207,10 +203,10 @@ public class BourneShellScriptTest {
         assertEquals("result\n", output.take());
         assertEquals("[+ echo result]", lines.toString());
     }
-    private static class MockHandler extends Handler {
-        private final BlockingQueue<Integer> status;
-        private final BlockingQueue<String> output;
-        private final BlockingQueue<String> lines;
+    static class MockHandler extends Handler {
+        final BlockingQueue<Integer> status;
+        final BlockingQueue<String> output;
+        final BlockingQueue<String> lines;
         @SuppressWarnings("unchecked")
         MockHandler(VirtualChannel channel, BlockingQueue<Integer> status, BlockingQueue<String> output, BlockingQueue<String> lines) {
             this.status = channel.export(BlockingQueue.class, status);
@@ -302,86 +298,6 @@ public class BourneShellScriptTest {
     @Test public void runWithTiniCommandLauncher() throws Exception {
         assumeTrue("Docker required for this test", new Docker().isAvailable());
         runOnDocker(new DumbSlave("docker", "/home/jenkins/agent", new SimpleCommandLauncher("docker run -i --rm --name agent --init jenkinsci/slave:3.7-1 java -jar /usr/share/jenkins/slave.jar")));
-    }
-
-    @Issue({"JENKINS-31096", "JENKINS-38381"})
-    @Test public void encoding() throws Exception {
-        JavaContainer container = dockerUbuntu.get();
-        DumbSlave s = new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "-Dfile.encoding=ISO-8859-1"));
-        j.jenkins.addNode(s);
-        j.waitOnline(s);
-        assertEquals("ISO-8859-1", s.getChannel().call(new DetectCharset()));
-        FilePath dockerWS = s.getWorkspaceRoot();
-        dockerWS.child("latin").write("¡Ole!\n", "ISO-8859-1");
-        dockerWS.child("eastern").write("Čau!\n", "ISO-8859-2");
-        dockerWS.child("mixed").write("¡Čau → there!\n", "UTF-8");
-        Launcher dockerLauncher = s.createLauncher(listener);
-        assertEncoding("control: no transcoding", "latin", null, "¡Ole!", "ISO-8859-1", false, dockerWS, dockerLauncher);
-        assertEncoding("test: specify particular charset (UTF-8)", "mixed", "UTF-8", "¡Čau → there!", "UTF-8", dockerWS, dockerLauncher);
-        assertEncoding("test: specify particular charset (unrelated)", "eastern", "ISO-8859-2", "Čau!", "UTF-8", dockerWS, dockerLauncher);
-        assertEncoding("test: specify agent default charset", "latin", "", "¡Ole!", "UTF-8", dockerWS, dockerLauncher);
-        assertEncoding("test: inappropriate charset, some replacement characters", "mixed", "US-ASCII", "����au ��� there!", "UTF-8", dockerWS, dockerLauncher);
-        s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
-    }
-    private static class DetectCharset extends MasterToSlaveCallable<String, RuntimeException> {
-        @Override public String call() throws RuntimeException {
-            return Charset.defaultCharset().name();
-        }
-    }
-    private void assertEncoding(String description, String file, String charset, String expected, String expectedEncoding, FilePath dockerWS, Launcher dockerLauncher) throws Exception {
-        assertEncoding(description, file, charset, expected, expectedEncoding, false, dockerWS, dockerLauncher);
-        assertEncoding(description, file, charset, expected, expectedEncoding, true, dockerWS, dockerLauncher);
-    }
-    private void assertEncoding(String description, String file, String charset, String expected, String expectedEncoding, boolean watch, FilePath dockerWS, Launcher dockerLauncher) throws Exception {
-        assertEncoding(description, file, charset, expected, expectedEncoding, false, watch, dockerWS, dockerLauncher);
-        assertEncoding(description, file, charset, expected, expectedEncoding, true, watch, dockerWS, dockerLauncher);
-    }
-    private void assertEncoding(String description, String file, String charset, String expected, String expectedEncoding, boolean output, boolean watch, FilePath dockerWS, Launcher dockerLauncher) throws Exception {
-        BourneShellScript dt = new BourneShellScript("set +x; cat " + file + "; sleep 1; tr '[a-z]' '[A-Z]' < " + file);
-        System.err.println(description + " (output=" + output + ", watch=" + watch + ")"); // TODO maybe this should just be moved into a new class and @RunWith(Parameterized.class) for clarity
-        if (charset != null) {
-            if (charset.isEmpty()) {
-                dt.defaultCharset();
-            } else {
-                dt.charset(Charset.forName(charset));
-            }
-        }
-        if (output) {
-            dt.captureOutput();
-        }
-        Controller c = dt.launch(new EnvVars(), dockerWS, dockerLauncher, listener);
-        String expectedUC = expected.toUpperCase(Locale.ENGLISH);
-        String fullExpected = expected + "\n" + expectedUC + "\n";
-        if (watch) {
-            BlockingQueue<Integer> status = new LinkedBlockingQueue<>();
-            BlockingQueue<String> stdout = new LinkedBlockingQueue<>();
-            BlockingQueue<String> lines = new LinkedBlockingQueue<>();
-            c.watch(dockerWS, new MockHandler(dockerWS.getChannel(), status, stdout, lines), listener);
-            assertEquals(description, "+ set +x", lines.take());
-            assertEquals(description, 0, status.take().intValue());
-            if (output) {
-                assertEquals(description, fullExpected, stdout.take());
-                assertEquals(description, "[]", lines.toString());
-            } else {
-                assertEquals(description, "<no output>", stdout.take());
-                assertEquals(description, "[" + expected + ", " + expectedUC + "]", lines.toString());
-            }
-        } else {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            OutputStream tee = new TeeOutputStream(baos, System.err);
-            while (c.exitStatus(dockerWS, dockerLauncher, listener) == null) {
-                c.writeLog(dockerWS, tee);
-                Thread.sleep(100);
-            }
-            c.writeLog(dockerWS, tee);
-            assertEquals(description, 0, c.exitStatus(dockerWS, dockerLauncher, listener).intValue());
-            if (output) {
-                assertEquals(description, fullExpected, new String(c.getOutput(dockerWS, launcher), expectedEncoding));
-            } else {
-                assertThat(description, baos.toString(expectedEncoding), containsString(fullExpected));
-            }
-        }
-        c.cleanup(dockerWS);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -1,0 +1,198 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.durabletask;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.plugins.sshslaves.SSHLauncher;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.OfflineCause;
+import hudson.util.StreamTaskListener;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.logging.Level;
+import jenkins.security.MasterToSlaveCallable;
+import org.apache.commons.io.output.TeeOutputStream;
+import static org.hamcrest.Matchers.containsString;
+import org.jenkinsci.test.acceptance.docker.DockerClassRule;
+import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+@Issue({"JENKINS-31096", "JENKINS-52165"})
+@RunWith(Parameterized.class)
+public class EncodingTest {
+
+    @ClassRule public static JenkinsRule r = new JenkinsRule();
+
+    @ClassRule public static DockerClassRule<JavaContainer> dockerUbuntu = new DockerClassRule<>(JavaContainer.class);
+
+    @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
+
+    @BeforeClass public static void unixAndDocker() throws Exception {
+        BourneShellScriptTest.unixAndDocker();
+    }
+
+    private static DumbSlave s;
+    private static StreamTaskListener listener;
+    private static FilePath ws;
+    private static Launcher launcher;
+
+    @BeforeClass public static void setUp() throws Exception {
+        listener = StreamTaskListener.fromStdout();
+        launcher = r.jenkins.createLauncher(listener);
+        JavaContainer container = dockerUbuntu.create();
+        s = new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "-Dfile.encoding=ISO-8859-1"));
+        r.jenkins.addNode(s);
+        r.waitOnline(s);
+        assertEquals("ISO-8859-1", s.getChannel().call(new DetectCharset()));
+        ws = s.getWorkspaceRoot();
+        launcher = s.createLauncher(listener);
+    }
+    private static class DetectCharset extends MasterToSlaveCallable<String, RuntimeException> {
+        @Override public String call() throws RuntimeException {
+            return Charset.defaultCharset().name();
+        }
+    }
+
+    @AfterClass public static void tearDown() throws Exception {
+        s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
+    }
+
+    public static final class TestCase {
+        final String description;
+        final String actualEncoding;
+        final String actualLine;
+        final String charset;
+        final String expectedLine;
+        final String expectedEncoding;
+        TestCase(String description, String actualEncoding, String actualLine, String charset, String expectedLine, String expectedEncoding) {
+            this.description = description;
+            this.actualEncoding = actualEncoding;
+            this.actualLine = actualLine;
+            this.charset = charset;
+            this.expectedLine = expectedLine;
+            this.expectedEncoding = expectedEncoding;
+        }
+        @Override public String toString() {
+            return description;
+        }
+    }
+
+    private static final TestCase[] CASES = {
+        new TestCase("(control) no transcoding", "ISO-8859-1", "¡Ole!", null, "¡Ole!", "ISO-8859-1"),
+        new TestCase("specify particular charset (UTF-8)", "UTF-8", "¡Čau → there!", "UTF-8", "¡Čau → there!", "UTF-8"),
+        new TestCase("specify particular charset (unrelated)", "ISO-8859-2", "Čau!", "ISO-8859-2", "Čau!", "UTF-8"),
+        new TestCase("specify agent default charset", "ISO-8859-1", "¡Ole!", "", "¡Ole!", "UTF-8"),
+        new TestCase("inappropriate charset, some replacement characters", "UTF-8", "¡Čau → there!", "US-ASCII", "����au ��� there!", "UTF-8"),
+    };
+
+    @Parameterized.Parameter(0) public TestCase testCase;
+
+    @Parameterized.Parameter(1) public boolean output;
+
+    @Parameterized.Parameter(2) public boolean watch;
+
+    @Parameterized.Parameters(name = "testCase={0}, output={1}, watch={2}") public static Iterable<Object[]> parameters() {
+        // TODO is there no utility method to produce the cross-product?
+        List<Object[]> params = new ArrayList<>();
+        for (TestCase testCase : CASES) {
+            for (boolean output : new boolean[] {false, true}) {
+                for (boolean watch : new boolean[] {false, true}) {
+                    params.add(new Object[] {testCase, output, watch});
+                }
+            }
+        }
+        return params;
+    }
+
+    @Test public void run() throws Exception {
+        ws.child("file").write(testCase.actualLine + '\n', testCase.actualEncoding);
+        BourneShellScript dt = new BourneShellScript("set +x; cat file; sleep 1; tr '[a-z]' '[A-Z]' < file");
+        if (testCase.charset != null) {
+            if (testCase.charset.isEmpty()) {
+                dt.defaultCharset();
+            } else {
+                dt.charset(Charset.forName(testCase.charset));
+            }
+            assertEquals("MockHandler is UTF-8 only", "UTF-8", testCase.expectedEncoding);
+        } else {
+            assumeFalse("Callers which use watch are expected to also specify an encoding", watch);
+        }
+        if (output) {
+            dt.captureOutput();
+        }
+        Controller c = dt.launch(new EnvVars(), ws, launcher, listener);
+        String expectedUC = testCase.expectedLine.toUpperCase(Locale.ENGLISH);
+        String fullExpected = testCase.expectedLine + "\n" + expectedUC + "\n";
+        if (watch) {
+            BlockingQueue<Integer> status = new LinkedBlockingQueue<>();
+            BlockingQueue<String> stdout = new LinkedBlockingQueue<>();
+            BlockingQueue<String> lines = new LinkedBlockingQueue<>();
+            c.watch(ws, new BourneShellScriptTest.MockHandler(ws.getChannel(), status, stdout, lines), listener);
+            assertEquals("+ set +x", lines.take());
+            assertEquals(0, status.take().intValue());
+            if (output) {
+                assertEquals(fullExpected, stdout.take());
+                assertEquals("[]", lines.toString());
+            } else {
+                assertEquals("<no output>", stdout.take());
+                assertEquals("[" + testCase.expectedLine + ", " + expectedUC + "]", lines.toString());
+            }
+        } else {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            OutputStream tee = new TeeOutputStream(baos, System.err);
+            while (c.exitStatus(ws, launcher, listener) == null) {
+                c.writeLog(ws, tee);
+                Thread.sleep(100);
+            }
+            c.writeLog(ws, tee);
+            assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
+            if (output) {
+                assertEquals(fullExpected, new String(c.getOutput(ws, launcher), testCase.expectedEncoding));
+            } else {
+                assertThat(baos.toString(testCase.expectedEncoding), containsString(fullExpected));
+            }
+        }
+        c.cleanup(ws);
+    }
+
+}


### PR DESCRIPTION
[JENKINS-52165](https://issues.jenkins-ci.org/browse/JENKINS-52165) Just the minimum changes pulled out of #29 to enable push rather than pull logging from durable tasks.