### PR TITLE
avoid bash error

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -140,7 +140,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         FilePath resultFile = c.getResultFile(ws);
         FilePath controlDir = c.controlDir(ws);
         if (capturingOutput) {
-            cmd = String.format("{ while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s'; wait",
+            cmd = String.format("\" while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,
@@ -151,7 +151,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                 logFile,
                 resultFile);
         } else {
-            cmd = String.format("{ while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s'; wait",
+            cmd = String.format("\" while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done \" & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,


### PR DESCRIPTION
While executing a k8s pipeline the command used to launch a script resulted in error.
`bash: syntax error near unexpected token 'do'`