### PR TITLE
[Fixed JENKINS-49754] - Prevent PowerShell stdout pollution when using returnStdout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -95,10 +95,16 @@ public final class PowershellScript extends FileMonitoringTask {
         args.addAll(Arrays.asList(powershellArgs.split(" ")));
         args.addAll(Arrays.asList("-Command", cmd));
         
+        // Exception propagation does not occur in legacy PowerShell versions. This means that an exception thrown in an inner PowerShell process
+        // does not propagate to the outer process regardless of $ErrorActionPreference selection. This ensures the exit code is non-zero if an error occurs regardless of PowerShell version.
         String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
                                              "param()\r\n" +
                                              "& %s %s -File '%s';\r\n" +
-                                             "exit $LASTEXITCODE;", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
+                                             "if ($Error) {\r\n" +
+                                             "  exit 1;\r\n" +
+                                             "} else {\r\n" +
+                                             "  exit $LASTEXITCODE;\r\n" + 
+                                             "}", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
         
         // Add an explicit exit to the end of the script so that exit codes are propagated
         String scriptWithExit = script + "\r\nexit $LASTEXITCODE;";

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -71,7 +71,7 @@ public final class PowershellScript extends FileMonitoringTask {
         if (capturingOutput) {
             cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;", 
                 quote(c.getPowerShellHelperFile(ws)),
-                quote(c.getPowerShellWrapperFile(ws)),
+                quote(c.getPowerShellScriptFile(ws)),
                 quote(c.getOutputFile(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));
@@ -95,16 +95,10 @@ public final class PowershellScript extends FileMonitoringTask {
         args.addAll(Arrays.asList(powershellArgs.split(" ")));
         args.addAll(Arrays.asList("-Command", cmd));
         
-        // Exception propagation does not occur in legacy PowerShell versions. This means that an exception thrown in an inner PowerShell process
-        // does not propagate to the outer process regardless of $ErrorActionPreference selection. This ensures the exit code is non-zero if an error occurs regardless of PowerShell version.
         String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
                                              "param()\r\n" +
                                              "& %s %s -File '%s';\r\n" +
-                                             "if ($Error) {\r\n" +
-                                             "  exit 1;\r\n" +
-                                             "} else {\r\n" +
-                                             "  exit $LASTEXITCODE;\r\n" + 
-                                             "}", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
+                                             "exit $LASTEXITCODE;", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
         
         // Add an explicit exit to the end of the script so that exit codes are propagated
         String scriptWithExit = script + "\r\nexit $LASTEXITCODE;";

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -109,11 +109,15 @@ public final class PowershellScript extends FileMonitoringTask {
         if (launcher.isUnix()) {
             // There is no need to add a BOM with Open PowerShell
             c.getPowerShellScriptFile(ws).write(scriptWithExit, "UTF-8");
-            c.getPowerShellWrapperFile(ws).write(scriptWrapper, "UTF-8");
+            if (!capturingOutput) {
+                c.getPowerShellWrapperFile(ws).write(scriptWrapper, "UTF-8");
+            }
         } else {
             // Write the Windows PowerShell scripts out with a UTF8 BOM
             writeWithBom(c.getPowerShellScriptFile(ws), scriptWithExit);
-            writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
+            if (!capturingOutput) {
+                writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
+            }
         }
         
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -124,7 +124,7 @@ public class PowershellScriptTest {
     }
     
     @Test public void implicitError() throws Exception {
-        Controller c = new PowershellScript("MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
+        Controller c = new PowershellScript("$ErrorActionPreference = 'Stop'; MyBogus-Cmdlet").launch(new EnvVars(), ws, launcher, listener);
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
@@ -161,13 +161,40 @@ public class PowershellScriptTest {
     
     @Test public void verbose() throws Exception {
         DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; Write-Verbose \"Hello, World!\"");
-        task.captureOutput();
         Controller c = task.launch(new EnvVars(), ws, launcher, listener);
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        assertEquals("VERBOSE: Hello, World!\r\n", new String(c.getOutput(ws, launcher)));
+        assertThat(baos.toString(), containsString("VERBOSE: Hello, World!\r\n"));
+        c.cleanup(ws);
+    }
+    
+    @Test public void debug() throws Exception {
+        DurableTask task = new PowershellScript("$DebugPreference = \"Continue\"; Write-Debug \"Hello, World!\"");
+        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertThat(baos.toString(), containsString("DEBUG: Hello, World!\r\n"));
+        c.cleanup(ws);
+    }
+    
+    @Test public void warning() throws Exception {
+        DurableTask task = new PowershellScript("$WarningPreference = \"Continue\"; Write-Warning \"Hello, World!\"");
+        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertEquals(0, c.exitStatus(ws, launcher).intValue());
+        assertThat(baos.toString(), containsString("WARNING: Hello, World!\r\n"));
         c.cleanup(ws);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -168,7 +168,22 @@ public class PowershellScriptTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        assertThat(baos.toString(), containsString("VERBOSE: Hello, World!\r\n"));
+        assertThat(baos.toString(), containsString("VERBOSE: Hello, World!"));
+        c.cleanup(ws);
+    }
+    
+    @Test public void verboseNegativeTest() throws Exception {
+        DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; Write-Verbose \"Hello, World!\"; Write-Output \"Success\"");
+        task.captureOutput();
+        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() == 0);
+        assertThat(baos.toString(), containsString("Hello, World!"));
+        assertEquals("Success\r\n", new String(c.getOutput(ws, launcher)));
         c.cleanup(ws);
     }
     
@@ -181,7 +196,7 @@ public class PowershellScriptTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        assertThat(baos.toString(), containsString("DEBUG: Hello, World!\r\n"));
+        assertThat(baos.toString(), containsString("DEBUG: Hello, World!"));
         c.cleanup(ws);
     }
     
@@ -194,7 +209,7 @@ public class PowershellScriptTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        assertThat(baos.toString(), containsString("WARNING: Hello, World!\r\n"));
+        assertThat(baos.toString(), containsString("WARNING: Hello, World!"));
         c.cleanup(ws);
     }
 


### PR DESCRIPTION
PowerShell output consists of 6 separate streams (success, error, warning, debug, verbose, and information), but only the success stream is conventionally considered to be stdout. The usage of returnStdout option of the PowerShell pipeline step should disregard all streams except the success stream to be consistent with other pipeline steps (bat, sh, etc.)

This PR prevents the warning, debug, verbose, or information streams from polluting stdout.

Caveats:
Normally in PowerShell when you use one of the various Write-* cmdlets, such as Write-Verbose or Write-Warning, the stream designation is prepended to the output. For example:
`Write-Verbose "This is some verbose output"`
Would yield:
> VERBOSE: This is some verbose output

There is a known issue when you invoke a PowerShell script and redirect the various streams to disk where this stream designation is omitted from the output. The solution for this is to wrap the execution of the script, which causes all of the non-error streams to be merged with stdout along with their corresponding designations.  However, this adds the side effect of treating all streams as normal stdout, which is undesirable when using returnStdout. So, with this change the stream designations will not be provided in the console log if using returnStdout. If not using returnStdout then the behavior remains the same as it is now.

I've also added a few extra unit tests to ensure that verbose, warning, and debug output continue to be correct.