### PR TITLE
Better fix to [JENKINS-25519] -- avoid errors when trying to read exitStatus from durable task before finished writing

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -152,8 +152,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                 scriptPath,
                 c.getOutputFile(ws),
                 logFile,
-                resultFile,
-                resultFile);
+                resultFile, resultFile, resultFile);
         } else {
             cmd = String.format("{ while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
                 controlDir,
@@ -163,8 +162,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                 cookieVariable,
                 scriptPath,
                 logFile,
-                resultFile,
-                resultFile);
+                resultFile, resultFile, resultFile);
         }
         cmd = cmd.replace("$", "$$"); // escape against EnvVars jobEnv in LocalLauncher.launch
 
@@ -212,6 +210,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             return controlDir(ws).child("pid");
         }
 
+        // TODO run as one big MasterToSlaveCallable<Integer> to avoid extra network roundtrips
         @Override public Integer exitStatus(FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
             Integer status = super.exitStatus(workspace, launcher, listener);
             if (status != null) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -138,9 +138,6 @@ public final class BourneShellScript extends FileMonitoringTask {
         String cmd;
         FilePath logFile = c.getLogFile(ws);
         FilePath resultFile = c.getResultFile(ws);
-        if (resultFile.exists()) {
-            resultFile.delete();  // Maybe overly cautious, but better safe than sorry, similarly we should make sure no duplicate logfile?
-        }
         FilePath controlDir = c.controlDir(ws);
         if (capturingOutput) {
             cmd = String.format("{ while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -235,7 +235,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                         if (pidFile.exists()) {
                             listener.getLogger().println("still have " + pidFile + " so heartbeat checks unreliable; process may or may not be alive");
                         } else {
-                            listener.getLogger().println("s " + controlDir);
+                            listener.getLogger().println("wrapper script does not seem to be touching the log file in " + controlDir);
                             listener.getLogger().println("(JENKINS-48300: if on a laggy filesystem, consider -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=300)");
                             return recordExitStatus(workspace, -1);
                         }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.durabletask;
 
+import com.google.common.io.Files;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -40,6 +41,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
@@ -48,6 +50,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.io.IOUtils;
+import org.jenkinsci.remoting.RoleChecker;
+
+import javax.annotation.CheckForNull;
 
 /**
  * A task which forks some external command and then waits for log and status files to be updated/created.
@@ -160,18 +165,28 @@ public abstract class FileMonitoringTask extends DurableTask {
             }
         }
 
+        /** Avoids excess round-tripping when reading status file. */
+        static class StatusCheck extends MasterToSlaveFileCallable<Integer> {
+            @Override
+            @CheckForNull
+            public Integer invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+                if (f.exists() && f.length() > 0) {
+                    try {
+                        return Integer.parseInt(Files.readFirstLine(f, Charset.defaultCharset()));
+                    } catch (NumberFormatException x) {
+                        throw new IOException("corrupted content in " + f + ": " + x, x);
+                    }
+                }
+                return null;
+            }
+        }
+
+        static final StatusCheck STATUS_CHECK_INSTANCE = new StatusCheck();
+
         // TODO would be more efficient to allow API to consolidate writeLog with exitStatus (save an RPC call)
         @Override public Integer exitStatus(FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
             FilePath status = getResultFile(workspace);
-            if (status.exists() && status.length() > 0) {  // Length 0 can happen if we're sloppy and do not write status atomically.
-                try {
-                    return Integer.parseInt(status.readToString().trim());
-                } catch (NumberFormatException x) {
-                    throw new IOException("corrupted content in " + status + ": " + x, x);
-                }
-            } else {
-                return null;
-            }
+            return status.act(STATUS_CHECK_INSTANCE);
         }
 
         @Override public byte[] getOutput(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -193,7 +193,6 @@ public abstract class FileMonitoringTask extends DurableTask {
 
         static final StatusCheck STATUS_CHECK_INSTANCE = new StatusCheck();
 
-        // TODO would be more efficient to allow API to consolidate writeLog with exitStatus (save an RPC call)
         @Override public Integer exitStatus(FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
             FilePath status = getResultFile(workspace);
             return status.act(STATUS_CHECK_INSTANCE);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -163,7 +163,7 @@ public abstract class FileMonitoringTask extends DurableTask {
         // TODO would be more efficient to allow API to consolidate writeLog with exitStatus (save an RPC call)
         @Override public Integer exitStatus(FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
             FilePath status = getResultFile(workspace);
-            if (status.exists()) {
+            if (status.exists() && status.length() > 0) {  // Length 0 can happen if we're sloppy and do not write status atomically.
                 try {
                     return Integer.parseInt(status.readToString().trim());
                 } catch (NumberFormatException x) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -172,7 +172,17 @@ public abstract class FileMonitoringTask extends DurableTask {
             public Integer invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
                 if (f.exists() && f.length() > 0) {
                     try {
-                        return Integer.parseInt(Files.readFirstLine(f, Charset.defaultCharset()));
+                        String fileString = Files.readFirstLine(f, Charset.defaultCharset());
+                        if (fileString == null || fileString.isEmpty()) {
+                            return null;
+                        } else {
+                            fileString = fileString.trim();
+                            if (fileString.isEmpty()) {
+                                return null;
+                            } else {
+                                return Integer.parseInt(fileString);
+                            }
+                        }
                     } catch (NumberFormatException x) {
                         throw new IOException("corrupted content in " + f + ": " + x, x);
                     }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -60,17 +60,18 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         BatchController c = new BatchController(ws);
 
         String cmd;
+        String quotedResultFile = quote(c.getResultFile(ws));
         if (capturingOutput) {
-            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
+            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s.tmp\"\r\nmove \"%s.tmp\" \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getOutputFile(ws)),
                 quote(c.getLogFile(ws)),
-                quote(c.getResultFile(ws)));
+                quotedResultFile, quotedResultFile, quotedResultFile);
         } else {
-            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
+            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s.tmp\"\r\nmove \"%s.tmp\" \"%s\"\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getLogFile(ws)),
-                quote(c.getResultFile(ws)));
+                quotedResultFile, quotedResultFile, quotedResultFile);
         }
         c.getBatchFile1(ws).write(cmd, "UTF-8");
         c.getBatchFile2(ws).write(script, "UTF-8");


### PR DESCRIPTION
Superior version of https://github.com/jenkinsci/durable-task-plugin/pull/65

Proposed solution to error like this, encountered when statusCode file exists but is empty, potentially when created but not written to yet, or not written fully.  Was confirmed that previous version removed the errors with the "corrupt" status file content and greatly reduced failure rates.

> java.lang.NumberFormatException: For input string: ""
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:592)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController.exitStatus(FileMonitoringTask.java:168)
> Caused: java.io.IOException: corrupted content in $SOMEPLACE 
> at org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController.exitStatus(FileMonitoringTask.java:170)
	at org.jenkinsci.plugins.durabletask.BourneShellScript$ShellController.exitStatus(BourneShellScript.java:211)

Variant of [JENKINS-25519](https://issues.jenkins-ci.org/browse/JENKINS-25519)