### PR TITLE
[JENKINS-TBD] Fix hung Batch steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -68,7 +68,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
                 quote(c.getLogFile(ws)),
                 quotedResultFile, quotedResultFile, quotedResultFile);
         } else {
-            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s.tmp\"\r\nmove \"%s.tmp\" \"%s\"\n",
+            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s.tmp\"\r\nmove \"%s.tmp\" \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getLogFile(ws)),
                 quotedResultFile, quotedResultFile, quotedResultFile);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -60,18 +60,17 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         BatchController c = new BatchController(ws);
 
         String cmd;
-        String quotedResultFile = quote(c.getResultFile(ws));
         if (capturingOutput) {
-            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s.tmp\"\r\nmove \"%s.tmp\" \"%s\"\r\n",
+            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getOutputFile(ws)),
                 quote(c.getLogFile(ws)),
-                quotedResultFile, quotedResultFile, quotedResultFile);
+                quote(c.getResultFile(ws)));
         } else {
-            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s.tmp\"\r\nmove \"%s.tmp\" \"%s\"\r\n",
+            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getLogFile(ws)),
-                quotedResultFile, quotedResultFile, quotedResultFile);
+                quote(c.getResultFile(ws)));
         }
         c.getBatchFile1(ws).write(cmd, "UTF-8");
         c.getBatchFile2(ws).write(script, "UTF-8");


### PR DESCRIPTION
Should fix a regression [JENKINS-50025](https://issues.jenkins-ci.org/browse/JENKINS-50025) introduced in #66 -- a subtle issue that may revolve around a quirk of path handling in Windows. 

This triggers symptoms matching [JENKINS-34150](https://issues.jenkins-ci.org/browse/JENKINS-34150).  

After an hour of investigation with the user (results noted in ticket) and without an ability to easily reproduce the issue, **I am backing out the previous change to the BatchScriptDurableTask.**  

Other components of #66 (the zero-length file check) should adequately ensure Windows coverage for [JENKINS-25519](https://issues.jenkins-ci.org/browse/JENKINS-25519), and I'd rather go back to a known-good version than risk a second regression.  This version was tested with the user and confirmed to work correctly.