### PR TITLE
Fix test failure under non-english Windows

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -204,7 +204,8 @@ public class PowershellScriptTest {
     }
     
     @Test public void specialStreams() throws Exception {
-        DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; " +
+        DurableTask task = new PowershellScript("[Threading.Thread]::CurrentThread.CurrentUICulture = 'en-US'; " +
+                                                "$VerbosePreference = \"Continue\"; " +
                                                 "$WarningPreference = \"Continue\"; " +
                                                 "$DebugPreference = \"Continue\"; " +
                                                 "Write-Verbose \"Hello, Verbose!\"; " +


### PR DESCRIPTION
If you are using a non-english version of Windows, your PowerShell is configured to run in your language. And so, the test PowershellScriptTest#specialStreams() that will test for the presence of "VERBOSE" will receive String that are dependent on your language.
In french, I see : 
```
COMMENTAIRES : Hello, Verbose!
AVERTISSEMENT : Hello, Warning!
DÉBOGUER : Hello, Debug!
```

instead of the expected

```
VERBOSE: Hello, Verbose!
WARNING: Hello, Warning!
DEBUG: Hello, Debug!
```

By fixing the language before running the command, this will solve this problem (and not impact other test cases). If you are using a english Windows, you can just change the en-US to fr-FR to see the difference.

@reviewbybees 