### PR TITLE
[Fixed JENKINS-50840] Reduce PowerShell footprint

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -98,12 +98,7 @@ public final class PowershellScript extends FileMonitoringTask {
         // Ensure backwards compatibility with PowerShell 3,4 for proper error propagation while also ensuring that output stream designations are present in PowerShell 5+
         String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
                                              "param()\r\n" +
-                                             "$scriptPath = '%s';\r\n" +
-                                             "if ($PSVersionTable.PSVersion.Major -ge 5) {\r\n" +
-                                             "  & " + powershellBinary + " " + powershellArgs + " -File $scriptPath;\r\n" +
-                                             "} else {\r\n" +
-                                             "  & $scriptPath;\r\n" +
-                                             "}\r\n" +
+                                             "& '%s';\r\n" +
                                              "exit $LASTEXITCODE;", quote(c.getPowerShellScriptFile(ws)));
         
         // Add an explicit exit to the end of the script so that exit codes are propagated

--- a/src/main/resources/org/jenkinsci/plugins/durabletask/powershellHelper.ps1
+++ b/src/main/resources/org/jenkinsci/plugins/durabletask/powershellHelper.ps1
@@ -14,6 +14,24 @@ param (
   return $writer;
 }
 
+function Get-StreamDesignation {
+[CmdletBinding()]
+param(
+  [Parameter(ValueFromPipeline = $true)] [object] $InputObject
+)
+  $StreamPrefix = "";
+  if ($InputObject) {
+      if ($InputObject.GetType().Name -eq 'VerboseRecord') {
+        $StreamPrefix = 'VERBOSE: ';
+      } elseif ($InputObject.GetType().Name -eq 'DebugRecord') {
+        $StreamPrefix = 'DEBUG: ';
+      } elseif ($InputObject.GetType().Name -eq 'WarningRecord') {
+        $StreamPrefix = 'WARNING: ';
+      }
+  }
+  $StreamPrefix
+}
+
 function Out-FileNoBom {
 [CmdletBinding()]
 param(
@@ -22,7 +40,8 @@ param(
 )
   Process {
     if ($Writer) {
-      $Input | Out-String -Stream -Width 192 | ForEach-Object { $Writer.WriteLine( $_ ); }
+      $StreamDesignation = $InputObject | Get-StreamDesignation;
+      $Input | Out-String -Stream -Width 192 | ForEach-Object { $Writer.WriteLine( $StreamDesignation + $_ ); }
     } else {
       $Input;
     }

--- a/src/main/resources/org/jenkinsci/plugins/durabletask/powershellHelper.ps1
+++ b/src/main/resources/org/jenkinsci/plugins/durabletask/powershellHelper.ps1
@@ -21,13 +21,13 @@ param(
 )
   $StreamPrefix = "";
   if ($InputObject) {
-      if ($InputObject.GetType().Name -eq 'VerboseRecord') {
-        $StreamPrefix = 'VERBOSE: ';
-      } elseif ($InputObject.GetType().Name -eq 'DebugRecord') {
-        $StreamPrefix = 'DEBUG: ';
-      } elseif ($InputObject.GetType().Name -eq 'WarningRecord') {
-        $StreamPrefix = 'WARNING: ';
-      }
+    if ($InputObject.GetType().Name -eq 'VerboseRecord') {
+      $StreamPrefix = 'VERBOSE: ';
+    } elseif ($InputObject.GetType().Name -eq 'DebugRecord') {
+      $StreamPrefix = 'DEBUG: ';
+    } elseif ($InputObject.GetType().Name -eq 'WarningRecord') {
+      $StreamPrefix = 'WARNING: ';
+    }
   }
   $StreamPrefix
 }
@@ -38,10 +38,39 @@ param(
   [Parameter(Mandatory=$true, Position=0)][AllowNull()] [System.IO.StreamWriter] $Writer,
   [Parameter(ValueFromPipeline = $true)]                [object] $InputObject
 )
+  Begin {
+    # Create a buffer in case the input contains multiple objects that need to be flushed together, which is the case for formatted output
+    [array]$Buffer = @();
+  }
+
   Process {
-    if ($Writer) {
-      $StreamDesignation = $InputObject | Get-StreamDesignation;
-      $Input | Out-String -Stream -Width 192 | ForEach-Object { $Writer.WriteLine( $StreamDesignation + $_ ); }
+    if ($Writer -and $Input -and $Input.Count -gt 0) {
+      # Buffer the objects
+      $Input | ForEach-Object {
+        $Buffer += $_;
+      }
+
+      # Handle special internal format objects produced via format-* cmdlets
+      if (!$InputObject.GetType().FullName.StartsWith('Microsoft.PowerShell.Commands.Internal.Format','CurrentCultureIgnoreCase') -or 
+          ($InputObject.GetType().FullName.StartsWith('Microsoft.PowerShell.Commands.Internal.Format','CurrentCultureIgnoreCase') -and $InputObject.GetType().Name -ieq 'FormatEndData')) {
+
+        # Try to force the output as text, but fallback on default if this is unsuccessful
+        try {
+          $Stream = $Buffer | Out-String -Stream -Width 192 -ErrorAction Stop;
+        } catch {
+          $Stream = $Buffer;
+        }
+
+        # Get any special stream designation that could have been lost
+        $StreamDesignation = $InputObject | Get-StreamDesignation;
+
+        # Flush the buffer
+        $Stream | ForEach-Object {
+          $Writer.Write( $StreamDesignation );
+          $Writer.WriteLine( $_ ); 
+        }
+        $Buffer.Clear();
+      }
     } else {
       $Input;
     }
@@ -73,7 +102,7 @@ param(
     & { & $MainScript | Out-FileNoBom -Writer $OutputWriter } *>&1 | Out-FileNoBom -Writer $LogWriter;
   } catch {
     $errorCaught = $_;
-    $errorCaught | Out-String -Width 192 | Out-FileNoBom -Writer $LogWriter;
+    $errorCaught | Out-FileNoBom -Writer $LogWriter;
   } finally {
     if ($LASTEXITCODE -ne $null) {
       if ($LASTEXITCODE -eq 0 -and $errorCaught -ne $null) {


### PR DESCRIPTION
Currently the PowerShell pipeline step consumes 2 PowerShell processes on the Jenkins host. The reason for this was because of a quirk which causes redirected console output to lose the appropriate stream designation when merged with stdout, but was mitigated by wrapping execution in a second call to powershell.  This PR introduces a fix that reduces the footprint of PowerShell to a single process, which in turn reduces the Jenkins host load, and artificially injects the appropriate stream designations into the console output.

A side effect of this is that localization/culture of three common PowerShell output hints are lost: VERBOSE, WARNING, and DEBUG. This has some direct impact on the changes introduced in https://github.com/jenkinsci/durable-task-plugin/pull/69, in that on a host that has non-English localization the stream designation hints will be in English instead of the correct culture defined in the host system. I believe that the benefits of reduced load outweigh the cost of losing localization of 3 output hints.

This also fixes JENKINS-50840 by adding special handling to buffer PowerShell output from format-* cmdlets

@reviewbybees 