### PR TITLE
[Fixed JENKINS-50840] Simplifying PowerShell execution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -95,16 +95,10 @@ public final class PowershellScript extends FileMonitoringTask {
         args.addAll(Arrays.asList(powershellArgs.split(" ")));
         args.addAll(Arrays.asList("-Command", cmd));
         
-        // Ensure backwards compatibility with PowerShell 3,4 for proper error propagation while also ensuring that output stream designations are present in PowerShell 5+
         String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
                                              "param()\r\n" +
-                                             "$scriptPath = '%s';\r\n" +
-                                             "if ($PSVersionTable.PSVersion.Major -ge 5) {\r\n" +
-                                             "  & " + powershellBinary + " " + powershellArgs + " -File $scriptPath;\r\n" +
-                                             "} else {\r\n" +
-                                             "  & $scriptPath;\r\n" +
-                                             "}\r\n" +
-                                             "exit $LASTEXITCODE;", quote(c.getPowerShellScriptFile(ws)));
+                                             "& %s %s -Command \"& '%s'\";\r\n" +
+                                             "exit $LASTEXITCODE;", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
         
         // Add an explicit exit to the end of the script so that exit codes are propagated
         String scriptWithExit = script + "\r\nexit $LASTEXITCODE;";

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -217,15 +217,9 @@ public class PowershellScriptTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher).intValue());
-        if (psVersion >= 5) {
-            assertThat(baos.toString(), containsString("VERBOSE: Hello, Verbose!"));
-            assertThat(baos.toString(), containsString("WARNING: Hello, Warning!"));
-            assertThat(baos.toString(), containsString("DEBUG: Hello, Debug!"));
-        } else {
-            assertThat(baos.toString(), containsString("Hello, Verbose!"));
-            assertThat(baos.toString(), containsString("Hello, Warning!"));
-            assertThat(baos.toString(), containsString("Hello, Debug!"));
-        }
+        assertThat(baos.toString(), containsString("VERBOSE: Hello, Verbose!"));
+        assertThat(baos.toString(), containsString("WARNING: Hello, Warning!"));
+        assertThat(baos.toString(), containsString("DEBUG: Hello, Debug!"));
         c.cleanup(ws);
     }
 


### PR DESCRIPTION
This PR simplifies the wrapper that calls PowerShell to make it uniform across all supported PowerShell versions. This fixes an issue which prevents certain PowerShell output objects from being piped to disk, namely objects produced via Format-* cmdlets.