### PR TITLE
[JENKINS-50892] Ensure the toucher process exits if the main wrapper process is killed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -140,7 +140,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         FilePath resultFile = c.getResultFile(ws);
         FilePath controlDir = c.controlDir(ws);
         if (capturingOutput) {
-            cmd = String.format("{ while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
+            cmd = String.format("pid=$$; { while ps -o pid -p $pid | grep -q $pid && [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,
@@ -151,7 +151,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                 logFile,
                 resultFile, resultFile, resultFile);
         } else {
-            cmd = String.format("{ while [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
+            cmd = String.format("pid=$$; { while ps -o pid -p $pid | grep -q $pid && [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,


### PR DESCRIPTION
To the extent that I follow the analyses in [JENKINS-50892](https://issues.jenkins-ci.org/browse/JENKINS-50892) and [JENKINS-46283](https://issues.jenkins-ci.org/browse/JENKINS-46283) I suspect this will fix the problem. Something is still fishy—under some circumstances, something is killing the main wrapper process (the one whose `pid` is recorded here) and I do not know why or how to reproduce that.

Thanks to [this tip](https://stackoverflow.com/a/14880926/12916) for the liveness checking trick. Someone with a Mac ought to check that this works on OS X.

Note that superficially this looks to restore some stuff I deleted in #49. The difference here is that the PID checks are being done in an external process (so, no problems with JNA), and from a process in the same kernel namespace (so, no problems with `withDockerContainer` and its K8S equivalent I hope).