### PR TITLE
[JENKINS-52881] Avoid use of ps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -140,7 +140,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         FilePath resultFile = c.getResultFile(ws);
         FilePath controlDir = c.controlDir(ws);
         if (capturingOutput) {
-            cmd = String.format("pid=$$; { while ps -o pid | grep -q \"^\\s*$pid$\" && [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
+            cmd = String.format("pid=$$; { while [ \\( -d /proc/$pid -o \\! -d /proc/$$ \\) -a -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,
@@ -151,7 +151,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                 logFile,
                 resultFile, resultFile, resultFile);
         } else {
-            cmd = String.format("pid=$$; { while ps -o pid | grep -q \"^\\s*$pid$\" && [ -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
+            cmd = String.format("pid=$$; { while [ \\( -d /proc/$pid -o \\! -d /proc/$$ \\) -a -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -50,7 +50,6 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -213,12 +212,13 @@ public class BourneShellScriptTest {
         runOnDocker(new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "")));
     }
 
+    @Issue("JENKINS-52847")
     @Test public void runOnAlpineDocker() throws Exception {
         AlpineFixture container = dockerAlpine.get();
         runOnDocker(new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "")), 45);
     }
 
-    @Ignore("TODO sh: 1: ps: not found")
+    @Issue("JENKINS-52881")
     @Test public void runOnSlimDocker() throws Exception {
         SlimFixture container = dockerSlim.get();
         runOnDocker(new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "")), 45);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/SlimFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/SlimFixture.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.durabletask;
+
+import org.jenkinsci.test.acceptance.docker.DockerContainer;
+import org.jenkinsci.test.acceptance.docker.DockerFixture;
+
+/** Analog of {@link JavaContainer} but using Debian Slim. */
+@DockerFixture(id = "slim", ports = 22)
+public class SlimFixture extends DockerContainer {}
+

--- a/src/test/resources/org/jenkinsci/plugins/durabletask/SlimFixture/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/durabletask/SlimFixture/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:8-jre-slim
+RUN apt-get update -y && \
+    apt-get install -y \
+        openssh-server \
+        locales
+RUN dpkg --force-depends -r procps
+RUN mkdir -p /var/run/sshd
+RUN useradd test -d /home/test && \
+    mkdir -p /home/test/.ssh && \
+    chown -R test:test /home/test && \
+    echo "test:test" | chpasswd
+ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]

--- a/src/test/resources/org/jenkinsci/plugins/durabletask/SlimFixture/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/durabletask/SlimFixture/Dockerfile
@@ -3,6 +3,7 @@ RUN apt-get update -y && \
     apt-get install -y \
         openssh-server \
         locales
+# openssh installs procps, and thus /bin/ps, as a dependency, so to reproduce JENKINS-52881 we need to delete it:
 RUN dpkg --force-depends -r procps
 RUN mkdir -p /var/run/sshd
 RUN useradd test -d /home/test && \


### PR DESCRIPTION
[JENKINS-52881](https://issues.jenkins-ci.org/browse/JENKINS-52881)

Amends #75 + #77, which do not work when the system `ps` fails to support even the most basic standard options (apparently there are a lot of nonstandard forks out there), or does not exist at all. Use procfs when that is available (which should also be a bit more efficient); if not; the JENKINS-50892 fix is just skipped. (I guess—we never managed to write a test case for that bug.)