### PR TITLE
[JENKINS-48300] Increase the default HEARTBEAT_CHECK_INTERVAL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -65,8 +65,7 @@ public final class BourneShellScript extends FileMonitoringTask {
      * Seconds between heartbeat checks, where we check to see if
      * {@code jenkins-log.txt} is still being modified.
      */
-    @SuppressWarnings("FieldMayBeFinal")
-    private static int HEARTBEAT_CHECK_INTERVAL = Integer.getInteger(BourneShellScript.class.getName() + ".HEARTBEAT_CHECK_INTERVAL", 15);
+    static int HEARTBEAT_CHECK_INTERVAL = Integer.getInteger(BourneShellScript.class.getName() + ".HEARTBEAT_CHECK_INTERVAL", 300);
 
     /**
      * Minimum timestamp difference on {@code jenkins-log.txt} that is
@@ -233,7 +232,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                             listener.getLogger().println("still have " + pidFile + " so heartbeat checks unreliable; process may or may not be alive");
                         } else {
                             listener.getLogger().println("wrapper script does not seem to be touching the log file in " + controlDir);
-                            listener.getLogger().println("(JENKINS-48300: if on a laggy filesystem, consider -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=300)");
+                            listener.getLogger().println("(JENKINS-48300: if on an extremely laggy filesystem, consider -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=86400)");
                             return recordExitStatus(workspace, -1);
                         }
                     }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -122,6 +122,9 @@ public class BourneShellScriptTest {
     }
 
     @Test public void reboot() throws Exception {
+        int orig = BourneShellScript.HEARTBEAT_CHECK_INTERVAL;
+        BourneShellScript.HEARTBEAT_CHECK_INTERVAL = 15;
+        try {
         FileMonitoringTask.FileMonitoringController c = (FileMonitoringTask.FileMonitoringController) new BourneShellScript("sleep 999").launch(new EnvVars("killemall", "true"), ws, launcher, listener);
         Thread.sleep(1000);
         launcher.kill(Collections.singletonMap("killemall", "true"));
@@ -136,6 +139,9 @@ public class BourneShellScriptTest {
         assertEquals(Integer.valueOf(-1), c.exitStatus(ws, launcher, listener));
         assertTrue(log.contains("sleep 999"));
         c.cleanup(ws);
+        } finally {
+            BourneShellScript.HEARTBEAT_CHECK_INTERVAL = orig;
+        }
     }
 
     @Test public void justSlow() throws Exception {


### PR DESCRIPTION
[JENKINS-48300](https://issues.jenkins-ci.org/browse/JENKINS-48300) Amends a tuning parameter from #49. Also see #57. Better to err on the side of waiting longer for the heartbeat to be detected, at the cost of taking longer to abort the step in cases like a machine reboot.