### PR TITLE
[JENKINS-50902] Do not rely on shebang for sh invocation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -111,16 +111,16 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         FilePath shf = c.getScriptFile(ws);
 
-        String s = script, scriptPath;
-        final Jenkins jenkins = Jenkins.getInstance();
-        if (!s.startsWith("#!") && jenkins != null) {
-            String defaultShell = jenkins.getInjector().getInstance(Shell.DescriptorImpl.class).getShellOrDefault(ws.getChannel());
-            s = "#!"+defaultShell+" -xe\n" + s;
-        }
-        shf.write(s, "UTF-8");
+        shf.write(script, "UTF-8");
         shf.chmod(0755);
 
-        scriptPath = shf.getRemote();
+        final Jenkins jenkins = Jenkins.getInstance();
+        String interpreter = !script.startsWith("#!") && jenkins != null
+                ? "'" + jenkins.getInjector().getInstance(Shell.DescriptorImpl.class).getShellOrDefault(ws.getChannel()) + "' -xe "
+                : ""
+        ;
+
+        String scriptPath = shf.getRemote();
         List<String> args = new ArrayList<>();
 
         OsType os = ws.act(new getOsType());
@@ -139,23 +139,25 @@ public final class BourneShellScript extends FileMonitoringTask {
         FilePath resultFile = c.getResultFile(ws);
         FilePath controlDir = c.controlDir(ws);
         if (capturingOutput) {
-            cmd = String.format("pid=$$; { while [ \\( -d /proc/$pid -o \\! -d /proc/$$ \\) -a -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2> '%s'; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
+            cmd = String.format("pid=$$; { while [ \\( -d /proc/$pid -o \\! -d /proc/$$ \\) -a -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc %s '%s' > '%s' 2> '%s'; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,
                 cookieValue,
                 cookieVariable,
+                interpreter,
                 scriptPath,
                 c.getOutputFile(ws),
                 logFile,
                 resultFile, resultFile, resultFile);
         } else {
-            cmd = String.format("pid=$$; { while [ \\( -d /proc/$pid -o \\! -d /proc/$$ \\) -a -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc '%s' > '%s' 2>&1; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
+            cmd = String.format("pid=$$; { while [ \\( -d /proc/$pid -o \\! -d /proc/$$ \\) -a -d '%s' -a \\! -f '%s' ]; do touch '%s'; sleep 3; done } & jsc=%s; %s=$jsc %s '%s' > '%s' 2>&1; echo $? > '%s.tmp'; mv '%s.tmp' '%s'; wait",
                 controlDir,
                 resultFile,
                 logFile,
                 cookieValue,
                 cookieVariable,
+                interpreter,
                 scriptPath,
                 logFile,
                 resultFile, resultFile, resultFile);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -112,13 +112,15 @@ public final class BourneShellScript extends FileMonitoringTask {
         FilePath shf = c.getScriptFile(ws);
 
         shf.write(script, "UTF-8");
-        shf.chmod(0755);
 
         final Jenkins jenkins = Jenkins.getInstance();
-        String interpreter = !script.startsWith("#!") && jenkins != null
-                ? "'" + jenkins.getInjector().getInstance(Shell.DescriptorImpl.class).getShellOrDefault(ws.getChannel()) + "' -xe "
-                : ""
-        ;
+        String interpreter = "";
+        if (!script.startsWith("#!")) {
+            String shell = jenkins.getDescriptorByType(Shell.DescriptorImpl.class).getShellOrDefault(ws.getChannel());
+            interpreter = "'" + shell + "' -xe ";
+        } else {
+            shf.chmod(0755);
+        }
 
         String scriptPath = shf.getRemote();
         List<String> args = new ArrayList<>();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -250,7 +250,7 @@ public class BourneShellScriptTest {
         // Run script inside the container as this is system dependent
         DumbSlave node = createDockerSlave(dockerSlim.get());
         j.jenkins.addNode(node);
-        node.toComputer().waitUntilOnline();
+        j.waitOnline(node);
         launcher = node.createLauncher(listener);
         ws = node.getWorkspaceRoot().child("configuredInterpreter");
         ws.mkdirs();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -264,6 +264,15 @@ public class BourneShellScriptTest {
         assertThat(baos.toString(), containsString("echo"));
         assertThat(baos.toString(), containsString("/bash"));
         c.cleanup(ws);
+
+        setGlobalInterpreter("no_such_shell");
+        c = new BourneShellScript("echo $SHELL").launch(new EnvVars(), ws, launcher, listener);
+        awaitCompletion(c);
+        baos = new ByteArrayOutputStream();
+        c.writeLog(ws, new TeeOutputStream(baos, System.out));
+        assertNotEquals(0, c.exitStatus(ws, launcher, listener).intValue());
+        assertThat(baos.toString(), containsString("no_such_shell"));
+        c.cleanup(ws);
     }
 
     private void setGlobalInterpreter(String interpreter) {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50902

Current implementation has several limitations:

- Does not support executable paths relative to `$PATH` variable as Shell step does, therefore making it hard for pipeline and freestyle to coexist.
- Reduces portability as the shebang expects absolute path making it hard for windows and unix nodes to coexist.
- Shebang does support interpreters with whitespace in its name, though that is a trivial one.