### PR TITLE
Removing noise from start of step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -165,7 +165,6 @@ public final class BourneShellScript extends FileMonitoringTask {
         args.addAll(Arrays.asList("sh", "-c", cmd));
         LOGGER.log(Level.FINE, "launching {0}", args);
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
-        listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+/", "") + "] Running shell script"); // -x will give details
         boolean novel;
         synchronized (encounteredPaths) {
             Integer cnt = encounteredPaths.get(ws);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -121,7 +121,6 @@ public final class PowershellScript extends FileMonitoringTask {
         }
         
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
-        listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+(\\\\|/)", "") + "] Running PowerShell script");
         ps.readStdout().readStderr();
         ps.start();
 

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -76,7 +76,6 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         c.getBatchFile2(ws).write(script, "UTF-8");
 
         Launcher.ProcStarter ps = launcher.launch().cmds("cmd", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(escape(envVars)).pwd(ws).quiet(true);
-        listener.getLogger().println("[" + ws.getRemote().replaceFirst("^.+\\\\", "") + "] Running batch script"); // details printed by cmd
         /* Too noisy, and consumes a thread:
         ps.stdout(listener);
         */


### PR DESCRIPTION
There is no compelling reason to print these messages for every `sh` etc. step. The working directory is generally obvious from the script, and there is no other new information since the overall log or Blue Ocean or whatever indicates the nature of the step being run. I am not really sure why I ever added this message to begin with.