### PR TITLE
Implemented direct workspace file execution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -100,8 +100,16 @@ public final class PowershellScript extends FileMonitoringTask {
                                              "& %s %s -Command \"& '%s'\";\r\n" +
                                              "exit $LASTEXITCODE;", powershellBinary, powershellArgs, quote(c.getPowerShellScriptFile(ws)));
         
+        String scriptWithExit;
+        FilePath scriptFile = new FilePath(ws, script);
+        if (scriptFile.exists()) {
+            listener.getLogger().println("Info: running workspace script " + script);
+            scriptWithExit = scriptFile.readToString();
+        } else {
+            scriptWithExit = script;
+        }
         // Add an explicit exit to the end of the script so that exit codes are propagated
-        String scriptWithExit = script + "\r\nexit $LASTEXITCODE;";
+        scriptWithExit = scriptWithExit + "\r\nexit $LASTEXITCODE;";
         
         // Copy the helper script from the resources directory into the workspace
         c.getPowerShellHelperFile(ws).copyFrom(getClass().getResource("powershellHelper.ps1"));

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -73,7 +73,15 @@ public final class WindowsBatchScript extends FileMonitoringTask {
                 quote(c.getResultFile(ws)));
         }
         c.getBatchFile1(ws).write(cmd, "UTF-8");
-        c.getBatchFile2(ws).write(script, "UTF-8");
+
+        FilePath scriptFile = new FilePath(ws, script);
+
+        if (scriptFile.exists()) {
+            listener.getLogger().println("Info: running workspace script " + script);
+            scriptFile.copyTo(c.getBatchFile2(ws));
+        } else {
+            c.getBatchFile2(ws).write(script, "UTF-8");
+        }
 
         Launcher.ProcStarter ps = launcher.launch().cmds("cmd", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(escape(envVars)).pwd(ws).quiet(true);
         /* Too noisy, and consumes a thread:


### PR DESCRIPTION
Kinda does what [JENKINS-54857](https://issues.jenkins-ci.org/browse/JENKINS-54857) wants.
Now commands like

```
sh 'build.sh'
bat 'build.bat'
powershell 'build.ps1'
```

run files present in the workspace, if they exist.