### PR TITLE
always force an interpreter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -119,7 +119,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             String shell = jenkins.getDescriptorByType(Shell.DescriptorImpl.class).getShellOrDefault(ws.getChannel());
             interpreter = "'" + shell + "' -xe ";
         } else {
-            shf.chmod(0755);
+            interpreter = script.split("[\\r\\n]")[0].replaceAll("#!", '');
         }
 
         String scriptPath = shf.getRemote();


### PR DESCRIPTION
Pipeline jobs including an sh step are including a shebang on the underlying script. Such shebang caused the script to be mode changed to executable. These "executables", when written on a mounted filesystem with the noexec flag, become non-executable (causing a not obvious failure).

Replacing the bare executable script with a call to the runner defined at the shebang, avoids this situation