### PR TITLE
Shell.DescriptorImpl.getShellOrDefault is not reliable in the presence of LauncherDecorator

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -136,7 +136,11 @@ public final class BourneShellScript extends FileMonitoringTask {
         final Jenkins jenkins = Jenkins.getInstance();
         String interpreter = "";
         if (!script.startsWith("#!")) {
-            String shell = jenkins.getDescriptorByType(Shell.DescriptorImpl.class).getShellOrDefault(ws.getChannel());
+            String shell = jenkins.getDescriptorByType(Shell.DescriptorImpl.class).getShell();
+            if (shell == null) {
+                // Do not use getShellOrDefault, as that assumes that the filesystem layout of the agent matches that seen from a possibly decorated launcher.
+                shell = "sh";
+            }
             interpreter = "'" + shell + "' -xe ";
         } else {
             shf.chmod(0755);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -27,13 +27,11 @@ package org.jenkinsci.plugins.durabletask;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.Computer;
 import hudson.model.Slave;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
-import hudson.slaves.SlaveComputer;
 import hudson.tasks.Shell;
 import hudson.util.StreamTaskListener;
 import hudson.util.VersionNumber;
@@ -248,7 +246,7 @@ public class BourneShellScriptTest {
     @Issue("JENKINS-50902")
     @Test public void configuredInterpreter() throws Exception {
         // Run script inside the container as this is system dependent
-        DumbSlave node = createDockerSlave(dockerSlim.get());
+        DumbSlave node = createDockerSlave(dockerSlim.get(), SlimFixture.SLIM_JAVA_LOCATION);
         j.jenkins.addNode(node);
         j.waitOnline(node);
         launcher = node.createLauncher(listener);
@@ -297,28 +295,28 @@ public class BourneShellScriptTest {
 
     @Test public void runOnUbuntuDocker() throws Exception {
         JavaContainer container = dockerUbuntu.get();
-        runOnDocker(createDockerSlave(container));
+        runOnDocker(createDockerSlave(container, null));
     }
 
     @Test public void runOnCentOSDocker() throws Exception {
         CentOSFixture container = dockerCentOS.get();
-        runOnDocker(createDockerSlave(container));
+        runOnDocker(createDockerSlave(container, null));
     }
 
     @Issue("JENKINS-52847")
     @Test public void runOnAlpineDocker() throws Exception {
         AlpineFixture container = dockerAlpine.get();
-        runOnDocker(createDockerSlave(container), 45);
+        runOnDocker(createDockerSlave(container, null), 45);
     }
 
     @Issue("JENKINS-52881")
     @Test public void runOnSlimDocker() throws Exception {
         SlimFixture container = dockerSlim.get();
-        runOnDocker(createDockerSlave(container), 45);
+        runOnDocker(createDockerSlave(container, SlimFixture.SLIM_JAVA_LOCATION), 45);
     }
 
-    private DumbSlave createDockerSlave(DockerContainer container) throws hudson.model.Descriptor.FormException, IOException {
-        return new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", ""));
+    private DumbSlave createDockerSlave(DockerContainer container, String javaPath) throws hudson.model.Descriptor.FormException, IOException {
+        return new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "", javaPath, null, null));
     }
 
     private void runOnDocker(DumbSlave s) throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/SlimFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/SlimFixture.java
@@ -29,5 +29,8 @@ import org.jenkinsci.test.acceptance.docker.DockerFixture;
 
 /** Analog of {@link JavaContainer} but using Debian Slim. */
 @DockerFixture(id = "slim", ports = 22)
-public class SlimFixture extends DockerContainer {}
+public class SlimFixture extends DockerContainer {
 
+    public static final String SLIM_JAVA_LOCATION = "/usr/local/openjdk-8/bin/java";
+
+}


### PR DESCRIPTION
Just because the container running the Jenkins agent has `/bin/sh` does not mean the container running the actual process will. For that matter, the remote callable does not even check—it just blindly returns `/bin/sh` on non-Windows platforms. Useless.

May conflict with #92, though that retains the shell launcher as a fallback.

See https://github.com/jenkinsci/kubernetes-plugin/pull/490 for integration test.