### PR TITLE
[JENKINS-58290] Run wrapper process in the background

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -61,6 +61,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
     private static final String SYSTEM_DEFAULT_CHARSET = "SYSTEM_DEFAULT";
 
+    private static final String LAUNCH_DIAGNOSTICS_PROP = BourneShellScript.class.getName() + ".LAUNCH_DIAGNOSTICS";
     /**
      * Whether to stream stdio from the wrapper script, which should normally not print any.
      * Copying output from the controller process consumes a Java thread, so we want to avoid it generally.
@@ -70,7 +71,7 @@ public final class BourneShellScript extends FileMonitoringTask {
      */
     @SuppressWarnings("FieldMayBeFinal")
     // TODO use SystemProperties if and when unrestricted
-    private static boolean LAUNCH_DIAGNOSTICS = Boolean.getBoolean(BourneShellScript.class.getName() + ".LAUNCH_DIAGNOSTICS");
+    private static boolean LAUNCH_DIAGNOSTICS = Boolean.getBoolean(LAUNCH_DIAGNOSTICS_PROP);
 
     /**
      * Seconds between heartbeat checks, where we check to see if
@@ -241,6 +242,9 @@ public final class BourneShellScript extends FileMonitoringTask {
                 long currentTimestamp = getLogFile(workspace).lastModified();
                 if (currentTimestamp == 0) {
                     listener.getLogger().println("process apparently never started in " + controlDir);
+                    if (!LAUNCH_DIAGNOSTICS) {
+                        listener.getLogger().println("(running Jenkins temporarily with -D" + LAUNCH_DIAGNOSTICS_PROP + "=true might make the problem clearer)");
+                    }
                     return recordExitStatus(workspace, -2);
                 } else if (checkedTimestamp > 0) {
                     if (currentTimestamp < checkedTimestamp) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -181,8 +181,8 @@ public final class BourneShellScript extends FileMonitoringTask {
         if (LAUNCH_DIAGNOSTICS) {
             args.addAll(Arrays.asList("sh", "-c", cmd));
         } else {
-            // setsid --fork also works but not in, say, busybox; or even Ubuntu prior to Cosmic
-            args.addAll(Arrays.asList("sh", "-c", "(" + cmd + ") &"));
+            // https://github.com/moby/moby/issues/33039#issuecomment-353250651
+            args.addAll(Arrays.asList("sh", "-c", "(" + cmd + ") >&- 2>&- &"));
         }
         LOGGER.log(Level.FINE, "launching {0}", args);
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -40,12 +40,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.TeeOutputStream;
@@ -331,33 +330,12 @@ public class BourneShellScriptTest {
         j.waitOnline(s);
         FilePath dockerWS = s.getWorkspaceRoot();
         Launcher dockerLauncher = s.createLauncher(listener);
-        final AtomicBoolean wrapperExited = new AtomicBoolean();
+        final AtomicReference<Proc> proc = new AtomicReference<>();
         Launcher decorated = new Launcher.DecoratedLauncher(dockerLauncher) {
             @Override public Proc launch(Launcher.ProcStarter starter) throws IOException {
-                final Proc delegate = super.launch(starter);
-                class DecoratedProc extends Proc {
-                    @Override public int join() throws IOException, InterruptedException {
-                        int r = delegate.join();
-                        wrapperExited.set(true);
-                        return r;
-                    }
-                    @Override public boolean isAlive() throws IOException, InterruptedException {
-                        return delegate.isAlive();
-                    }
-                    @Override public void kill() throws IOException, InterruptedException {
-                        delegate.kill();
-                    }
-                    @Override public InputStream getStdout() {
-                        return delegate.getStdout();
-                    }
-                    @Override public InputStream getStderr() {
-                        return delegate.getStderr();
-                    }
-                    @Override public OutputStream getStdin() {
-                        return delegate.getStdin();
-                    }
-                }
-                return new DecoratedProc();
+                Proc delegate = super.launch(starter);
+                assertTrue(proc.compareAndSet(null, delegate));
+                return delegate;
             }
         };
         String script = String.format("echo hello world; sleep 5; echo long since started; sleep %s", sleepSeconds - 5);
@@ -367,7 +345,8 @@ public class BourneShellScriptTest {
         while (c.exitStatus(dockerWS, dockerLauncher, listener) == null) {
             c.writeLog(dockerWS, baos);
             if (baos.toString().contains("long since started")) {
-                assertTrue("wrapper process still running:\n" + baos, wrapperExited.get());
+                assertNotNull(proc.get());
+                assertFalse("JENKINS-58290: wrapper process still running:\n" + baos, proc.get().isAlive());
             }
             Thread.sleep(100);
         }


### PR DESCRIPTION
[JENKINS-58290](https://issues.jenkins-ci.org/browse/JENKINS-58290)

~Alternative to #97: regardless of the `Proc` implementation~ ~Call `Proc.join` after launch~ Make sure we use `&` to launch the wrapper process as a background process. I would hope (but have not yet checked) that #92 also passes the same test (CC @car-roll).

~To my surprise, this does _not_ solve https://github.com/jenkinsci/kubernetes-plugin/pull/522. While `ContainerExecProc.join` calls `close` at the end, `join` never completes, despite the attempt at backgrounding, and so the WebSocket remains open. So there is something fishy going on which I have not identified.~ Seems that https://github.com/moby/moby/issues/33039#issuecomment-353250651 is key.