### PR TITLE
Update to the newest ssh-slaves version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.32.3'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <properties>
         <revision>1.31</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.150.1</jenkins.version>
+        <java.level>8</java.level>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
     
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.25</version>
+            <version>1.30.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -60,4 +60,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>symbol-annotation</artifactId>
+                <version>1.7</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -24,6 +24,11 @@
 
 package org.jenkinsci.plugins.durabletask;
 
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -318,7 +323,10 @@ public class BourneShellScriptTest {
     }
 
     private DumbSlave createDockerSlave(DockerContainer container, String javaPath) throws hudson.model.Descriptor.FormException, IOException {
-        return new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "", javaPath, null, null));
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(Domain.global(), Collections.<Credentials>singletonList(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "test", "test"))));
+        SSHLauncher sshLauncher = new SSHLauncher(container.ipBound(22), container.port(22), "test");
+        sshLauncher.setJavaPath(javaPath);
+        return new DumbSlave("docker", "/home/test", sshLauncher);
     }
 
     private void runOnDocker(DumbSlave s) throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -24,6 +24,11 @@
 
 package org.jenkinsci.plugins.durabletask;
 
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -35,6 +40,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
@@ -80,7 +86,10 @@ public class EncodingTest {
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
         JavaContainer container = dockerUbuntu.create();
-        s = new DumbSlave("docker", "/home/test", new SSHLauncher(container.ipBound(22), container.port(22), "test", "test", "", "-Dfile.encoding=ISO-8859-1"));
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(Domain.global(), Collections.<Credentials>singletonList(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "test", "test"))));
+        SSHLauncher sshLauncher = new SSHLauncher(container.ipBound(22), container.port(22), "test");
+        sshLauncher.setJvmOptions("-Dfile.encoding=ISO-8859-1");
+        s = new DumbSlave("docker", "/home/test", sshLauncher);
         r.jenkins.addNode(s);
         r.waitOnline(s);
         assertEquals("ISO-8859-1", s.getChannel().call(new DetectCharset()));


### PR DESCRIPTION
https://github.com/jenkinsci/ssh-slaves-plugin/pull/114 was incompatible, so this plugin failed in `plugin-compat-tester`.