### PR TITLE
Do not fail tests when run on a machine without Docker installed

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -80,7 +80,7 @@ public class BourneShellScriptTest {
         assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
     }
 
-    private void assumeDocker() throws Exception {
+    static void assumeDocker() throws Exception {
         assumeTrue("Docker is available", new Docker().isAvailable());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         assumeThat("`docker version` could be run", new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds("docker", "version", "--format", "{{.Client.Version}}").stdout(new TeeOutputStream(baos, System.err)).stderr(System.err).join(), is(0));

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -68,7 +68,8 @@ public class EncodingTest {
     @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
     @BeforeClass public static void unixAndDocker() throws Exception {
-        BourneShellScriptTest.unixAndDocker();
+        BourneShellScriptTest.unix();
+        BourneShellScriptTest.assumeDocker();
     }
 
     private static DumbSlave s;


### PR DESCRIPTION
A problem for some used of PCT:

```
java.io.IOException: Cannot run program "docker": error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at hudson.Proc$LocalProc.<init>(Proc.java:250)
	at hudson.Proc$LocalProc.<init>(Proc.java:219)
	at hudson.Launcher$LocalLauncher.launch(Launcher.java:937)
	at hudson.Launcher$ProcStarter.start(Launcher.java:455)
	at hudson.Launcher$ProcStarter.join(Launcher.java:466)
	at org.jenkinsci.plugins.durabletask.BourneShellScriptTest.unixAndDocker(BourneShellScriptTest.java:82)
	at …
Caused by: java.io.IOException: error=2, No such file or directory
	at java.lang.UNIXProcess.forkAndExec(Native Method)
	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
	... 23 more
```