### PR TITLE
[JENKINS-59903]  [JENKINS-59907]  caching with docker and uncommon architectures issues

### DIFF
--- a/src/main/go/org/jenkinsci/plugins/durabletask/rebuild.sh
+++ b/src/main/go/org/jenkinsci/plugins/durabletask/rebuild.sh
@@ -1,5 +1,9 @@
 #! /bin/sh
 # Convenience script to rebuild golang binaries during development
+if [[ $1 -eq 0 ]] ; then
+    echo 'please provide a plugin version as an argument (ex: 1.32)'
+    exit 0
+fi
 set -x
 # maven plugin version
 VER=$1

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -196,7 +196,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         envVars.put(cookieVariable, "please-do-not-kill-me");
 
         List<String> launcherCmd = null;
-        if (agentInfo.isBinaryCompatible()) {
+        if (FORCE_BINARY_WRAPPER && agentInfo.isBinaryCompatible()) {
             FilePath controlDir = c.controlDir(ws);
             FilePath binary;
             if (agentInfo.isCachingAvailable()) {
@@ -205,7 +205,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                 binary = controlDir.child(agentInfo.getBinaryPath());
             }
             try (InputStream binaryStream = DurableTask.class.getResourceAsStream(binary.getName())) {
-                if (FORCE_BINARY_WRAPPER && (binaryStream != null)) {
+                if (binaryStream != null) {
                     if (!agentInfo.isCachingAvailable() || !agentInfo.isBinaryCached()) {
                         binary.copyFrom(binaryStream);
                         binary.chmod(0755);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -95,8 +95,6 @@ public final class BourneShellScript extends FileMonitoringTask {
         }
     }
 
-    private enum ArchBits {_32, _64}
-
     /**
      * Whether to stream stdio from the wrapper script, which should normally not print any.
      * Copying output from the controller process consumes a Java thread, so we want to avoid it generally.
@@ -405,16 +403,15 @@ public final class BourneShellScript extends FileMonitoringTask {
     }
 
     private static final class AgentInfo implements Serializable {
+        private static final long serialVersionUID = 7599995179651071957L;
         private final OsType os;
-        private final ArchBits archBits;
         private final String binaryPath;
         private boolean x86;
         private boolean binaryCached;
         private boolean cachingAvailable;
 
-        public AgentInfo(OsType os, ArchBits archBits, boolean x86, String binaryPath, boolean cachingAvailable) {
+        public AgentInfo(OsType os, boolean x86, String binaryPath, boolean cachingAvailable) {
             this.os = os;
-            this.archBits = archBits;
             this.binaryPath = binaryPath;
             this.x86 = x86;
             this.binaryCached = false;
@@ -423,10 +420,6 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         public OsType getOs() {
             return os;
-        }
-
-        public ArchBits getArchBits() {
-            return archBits;
         }
 
         public String getBinaryPath() {
@@ -456,6 +449,8 @@ public final class BourneShellScript extends FileMonitoringTask {
         private static final String CACHE_PATH = "caches/durable-task/";
         private String binaryVersion;
         private boolean x86;
+
+        private enum ArchBits {_32, _64}
 
         GetAgentInfo(String pluginVersion) {
             this.binaryVersion = pluginVersion;
@@ -501,13 +496,13 @@ public final class BourneShellScript extends FileMonitoringTask {
                 binaryPath = binaryFile.toPath().toString();
                 isCached = binaryFile.exists();
                 cachingAvailable = true;
-            } catch (IOException | SecurityException e) {
+            } catch (Exception e) {
                 // when the jenkins agent cache path is not accessible
                 binaryPath = binaryName;
                 isCached = false;
                 cachingAvailable = false;
             }
-            AgentInfo agentInfo = new AgentInfo(os, archBits, x86, binaryPath, cachingAvailable);
+            AgentInfo agentInfo = new AgentInfo(os, x86, binaryPath, cachingAvailable);
             agentInfo.setBinaryAvailability(isCached);
             return agentInfo;
         }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -81,7 +81,7 @@ import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.SimpleCommandLauncher;
 
 enum TestPlatform {
-    NATIVE, ALPINE, CENTOS, UBUNTU, SLIM, NO_INIT, UBUNTU_NO_BINARY
+    NATIVE, ALPINE, CENTOS, UBUNTU, NO_INIT, UBUNTU_NO_BINARY, SLIM
 }
 
 @RunWith(Parameterized.class)


### PR DESCRIPTION
This PR is attempting to resolve the issues outlined in JENKINS-59903 and JENKINS-59907.

In 59903, the issue occurs when a docker-based agent does not have access to the jenkins caching directory. This prevents the  binary from  ever being copied over to the agent. To fix this, whenever there is no access to the  cache directory, caching will be disabled for the agent and the binary will be copied over to the agent's control directory for every shell execution.

In 59907, the binary is attempting to launch on non-x86 architectures. This  behavior  is currently blocked as the binary has  only been tested on  x86 machines. For  non-x86, non-*NIX architectures, the shell wrapper will be used.