### PR TITLE
[JENKINS-59903] [JENKINS-59907] Disable golang binary as default

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -38,8 +38,6 @@ import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.tasks.Shell;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -75,7 +73,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_SHELL_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".FORCE_SHELL_WRAPPER");
+    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
 
     private static final Logger LOGGER = Logger.getLogger(BourneShellScript.class.getName());
 
@@ -203,7 +201,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         List<String> launcherCmd;
         FilePath binary = nodeRoot.child(agentInfo.getBinaryPath());
         try (InputStream binaryStream = DurableTask.class.getResourceAsStream(binary.getName())) {
-            if ((binaryStream != null) && !FORCE_SHELL_WRAPPER) {
+            if (FORCE_BINARY_WRAPPER && (binaryStream != null)) {
                 FilePath controlDir = c.controlDir(ws);
                 if (!agentInfo.isBinaryCached()) {
                     binary.copyFrom(binaryStream);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -124,15 +124,16 @@ public class BourneShellScriptTest {
     @Before public void prepareAgentForPlatform() throws Exception {
         switch (platform) {
             case NATIVE:
+                BourneShellScript.FORCE_BINARY_WRAPPER = true;
                 s = j.createOnlineSlave();
                 break;
-            case UBUNTU_NO_BINARY:
-                BourneShellScript.FORCE_SHELL_WRAPPER = true;
             case SLIM:
             case ALPINE:
             case CENTOS:
             case UBUNTU:
             case NO_INIT:
+                BourneShellScript.FORCE_BINARY_WRAPPER = true;
+            case UBUNTU_NO_BINARY:
                 assumeDocker();
                 s = prepareAgentDocker();
                 j.jenkins.addNode(s);
@@ -193,7 +194,7 @@ public class BourneShellScriptTest {
         if (s != null) {
             j.jenkins.removeNode(s);
         }
-        BourneShellScript.FORCE_SHELL_WRAPPER = false;
+        BourneShellScript.FORCE_BINARY_WRAPPER = false;
     }
 
     @Test public void smokeTest() throws Exception {


### PR DESCRIPTION
Disabling binary wrapper that was introduced in v1.31 by default. 

Added system property `org.jenkinsci.plugins.durabletask.BourneShellScript.FORCE_BINARY_WRAPPER` to enable the binary. 

#114 will be used to address the bugs.