### PR TITLE
[JENKINS-60960] fix/workaround memory leak on agent

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -29,6 +29,7 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Plugin;
+import hudson.Proc;
 import hudson.Launcher;
 import hudson.util.ListBoxModel;
 import hudson.util.ListBoxModel.Option;
@@ -133,7 +134,9 @@ public final class PowershellScript extends FileMonitoringTask {
         
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         ps.readStdout().readStderr();
-        ps.start();
+        Proc p = ps.start();
+        c.registerForCleanup(p.getStdout());
+        c.registerForCleanup(p.getStderr());
 
         return c;
     }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -81,7 +81,6 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         ps.stdout(listener);
         */
         ps.readStdout().readStderr(); // TODO see BourneShellScript
-        ps.start();
         Proc p = ps.start();
         c.registerForCleanup(p.getStdout());
         c.registerForCleanup(p.getStderr());

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -29,6 +29,7 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.Proc;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -81,6 +82,10 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         */
         ps.readStdout().readStderr(); // TODO see BourneShellScript
         ps.start();
+        Proc p = ps.start();
+        c.registerForCleanup(p.getStdout());
+        c.registerForCleanup(p.getStderr());
+
         return c;
     }
 


### PR DESCRIPTION
See [JENKINS-60960](https://issues.jenkins-ci.org/browse/JENKINS-60960).

First commit makes the `BourneShellScriptTest.smokeTest()` fail, by detecting that some `UNIXProcess$ProcessPipeInputStream` are retained by the agent's `ExportTable`.

Second commit fixes this issue, by ensuring these streams (which are not used otherwise) get closed once the controller process has exited.  Not sure if it qualifies as a `durable-task` bugfix, or as a core/remoting bug workaround in `durable-task`, but anyway, it's still an improvement :)

With this patch, if one looks at the agent's `ExportTable` after using `BourneShellScript` (for instance at the end of the `smokeTest`), the stdout and stderr `UNIXProcess$ProcessPipeInputStream` objects from the controller process can be found in the `ExportTable.unexportLog` with the following stack in `releaseTrace`:

```
hudson.remoting.ExportTable$Entry.release() (ExportTable.java:163)
hudson.remoting.ExportTable.unexportByOid() (ExportTable.java:521)
hudson.remoting.Channel.unexport() (Channel.java:803)
hudson.remoting.ProxyInputStream$EOF.execute() (ProxyInputStream.java:174)
hudson.remoting.Channel$1.handle() (Channel.java:565)
hudson.remoting.SynchronousCommandTransport$ReaderThread.run() (SynchronousCommandTransport.java:85)
```

... and this secondary `cause` stacktrace:

```
hudson.remoting.Command.<init>() (Command.java:79)
hudson.remoting.Command.<init>() (Command.java:62)
hudson.remoting.ProxyInputStream$EOF.<init>() (ProxyInputStream.java:162)
hudson.remoting.ProxyInputStream.close() (ProxyInputStream.java:101)
hudson.remoting.RemoteInputStream.close() (RemoteInputStream.java:287)
org.jenkinsci.remoting.util.IOUtils.closeQuietly() (IOUtils.java:55)
java.util.LinkedList$LLSpliterator.forEachRemaining() (LinkedList.java:1235)
java.util.stream.ReferencePipeline$Head.forEach() (ReferencePipeline.java:647)
org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController.cleanup() (FileMonitoringTask.java:365)
org.jenkinsci.plugins.durabletask.BourneShellScriptTest.smokeTest() (BourneShellScriptTest.java:232)
sun.reflect.NativeMethodAccessorImpl.invoke0() (NativeMethodAccessorImpl.java)
sun.reflect.NativeMethodAccessorImpl.invoke() (NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke() (DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke() (Method.java:498)
org.junit.runners.model.FrameworkMethod$1.runReflectiveCall() (FrameworkMethod.java:50)
org.junit.internal.runners.model.ReflectiveCallable.run() (ReflectiveCallable.java:12)
org.junit.runners.model.FrameworkMethod.invokeExplosively() (FrameworkMethod.java:47)
org.junit.internal.runners.statements.InvokeMethod.evaluate() (InvokeMethod.java:17)
org.junit.internal.runners.statements.RunBefores.evaluate() (RunBefores.java:26)
org.junit.internal.runners.statements.RunAfters.evaluate() (RunAfters.java:27)
org.jenkinsci.test.acceptance.docker.DockerRule$1.evaluate() (DockerRule.java:87)
org.jenkinsci.test.acceptance.docker.DockerRule$1.evaluate() (DockerRule.java:87)
org.jenkinsci.test.acceptance.docker.DockerRule$1.evaluate() (DockerRule.java:87)
org.jenkinsci.test.acceptance.docker.DockerRule$1.evaluate() (DockerRule.java:87)
org.jvnet.hudson.test.JenkinsRule$1.evaluate() (JenkinsRule.java:556)
org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call() (FailOnTimeout.java:298)
org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call() (FailOnTimeout.java:292)
java.util.concurrent.FutureTask.run() (FutureTask.java:266)
java.lang.Thread.run() (Thread.java:748)
```

Note that I've also modified `PowershellScript` and `WindowsBatchScript` in a similar way to what I did for `BourneShellScript`, but that's completely untested, to be honest.