### PR TITLE
make generate binaries script return error for failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 def builds = [:]
 builds['docker'] = { buildPlugin(platforms: ['docker']) }
 builds['windows'] = {
-    withEnv(['SKIP_BINARY_GENERATION=true']) {
+    withEnv(['SKIP_DURABLE_TASK_BINARY_GENERATION=true']) {
         buildPlugin(platforms: ['windows'])
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,26 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <version>1.0.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>set-system-properties</goal>
+                                </goals>
+                                <configuration>
+                                    <properties>
+                                        <property>
+                                            <name>org.jenkinsci.plugins.durabletask.BourneShellScriptTest.TEST_BINARY</name>
+                                            <value>true</value>
+                                        </property>
+                                    </properties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
                         <version>3.1.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,32 +74,12 @@
             <id>generate-binaries-profile</id>
             <activation>
                 <property>
-                    <name>env.SKIP_BINARY_GENERATION</name>
+                    <name>env.SKIP_DURABLE_TASK_BINARY_GENERATION</name>
                     <value>!true</value>
                 </property>
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>properties-maven-plugin</artifactId>
-                        <version>1.0.0</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>set-system-properties</goal>
-                                </goals>
-                                <configuration>
-                                    <properties>
-                                        <property>
-                                            <name>org.jenkinsci.plugins.durabletask.BourneShellScriptTest.TEST_BINARY</name>
-                                            <value>true</value>
-                                        </property>
-                                    </properties>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>

--- a/src/main/go/org/jenkinsci/plugins/durabletask/generate-binaries.sh
+++ b/src/main/go/org/jenkinsci/plugins/durabletask/generate-binaries.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-set -x
+set -ex
 # maven plugin version
 VER=$1
 # path to the golang source
@@ -15,8 +15,3 @@ docker run -i --rm \
 docker rmi ${IMG_NAME}:${VER}
 mkdir -p ${DST}
 mv ${BIN_NAME}_* ${DST}/
-if [ $? -ne 0 ]
-then
-  echo "Binary generation failed. To skip binary generation, set the environment variable 'SKIP_BINARY_GENERATION=true'"
-  exit 1
-fi

--- a/src/main/go/org/jenkinsci/plugins/durabletask/generate-binaries.sh
+++ b/src/main/go/org/jenkinsci/plugins/durabletask/generate-binaries.sh
@@ -12,6 +12,11 @@ docker build --build-arg PLUGIN_VER=${VER} -t ${IMG_NAME}:${VER} .
 docker run -i --rm \
     --mount type=bind,src=${SRC},dst=/org/jenkinsci/plugins/durabletask \
     ${IMG_NAME}:${VER}
+docker rmi ${IMG_NAME}:${VER}
 mkdir -p ${DST}
 mv ${BIN_NAME}_* ${DST}/
-docker rmi ${IMG_NAME}:${VER}
+if [ $? -ne 0 ]
+then
+  echo "Binary generation failed. To skip binary generation, set the environment variable 'SKIP_BINARY_GENERATION=true'"
+  exit 1
+fi

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -55,6 +55,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
@@ -94,10 +95,10 @@ public class BourneShellScriptTest {
     public static boolean TEST_BINARY = Boolean.getBoolean(BourneShellScriptTest.class.getName() + ".TEST_BINARY");
     @Parameters(name = "{index}: {0}")
     public static Object[] data() {
-        if (TEST_BINARY) {
-            return TestPlatform.values();
-        } else {
+        if (Objects.equals(System.getenv().get("SKIP_DURABLE_TASK_BINARY_GENERATION"), "true")) {
             return new TestPlatform[]{TestPlatform.NATIVE, TestPlatform.ALPINE, TestPlatform.CENTOS, TestPlatform.UBUNTU, TestPlatform.NO_INIT, TestPlatform.SLIM};
+        } else {
+            return TestPlatform.values();
         }
     }
 
@@ -477,7 +478,7 @@ public class BourneShellScriptTest {
     }
 
     @Test public void binaryCaching() throws Exception {
-        assumeTrue(TEST_BINARY && !platform.equals(TestPlatform.UBUNTU_NO_BINARY));
+        assumeTrue(!Objects.equals(System.getenv().get("SKIP_DURABLE_TASK_BINARY_GENERATION"), "true") && !platform.equals(TestPlatform.UBUNTU_NO_BINARY));
         String os;
         switch (platform) {
             case NATIVE:

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -55,6 +55,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
@@ -93,7 +94,11 @@ enum TestPlatform {
 public class BourneShellScriptTest {
     @Parameters(name = "{index}: {0}")
     public static Object[] data() {
-        return TestPlatform.values();
+        if (Objects.equals(System.getenv().get("SKIP_BINARY_GENERATION"), "true")) {
+            return new TestPlatform[]{TestPlatform.NATIVE, TestPlatform.ALPINE, TestPlatform.CENTOS, TestPlatform.UBUNTU, TestPlatform.NO_INIT, TestPlatform.SLIM};
+        } else {
+            return TestPlatform.values();
+        }
     }
 
     @Rule public JenkinsRule j = new JenkinsRule();
@@ -472,7 +477,7 @@ public class BourneShellScriptTest {
     }
 
     @Test public void binaryCaching() throws Exception {
-        assumeTrue(!platform.equals(TestPlatform.UBUNTU_NO_BINARY));
+        assumeTrue(!Objects.equals(System.getenv().get("SKIP_BINARY_GENERATION"), "true") && !platform.equals(TestPlatform.UBUNTU_NO_BINARY));
         String os;
         switch (platform) {
             case NATIVE:

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -55,7 +55,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
@@ -92,12 +91,13 @@ enum TestPlatform {
 
 @RunWith(Parameterized.class)
 public class BourneShellScriptTest {
+    public static boolean TEST_BINARY = Boolean.getBoolean(BourneShellScriptTest.class.getName() + ".TEST_BINARY");
     @Parameters(name = "{index}: {0}")
     public static Object[] data() {
-        if (Objects.equals(System.getenv().get("SKIP_BINARY_GENERATION"), "true")) {
-            return new TestPlatform[]{TestPlatform.NATIVE, TestPlatform.ALPINE, TestPlatform.CENTOS, TestPlatform.UBUNTU, TestPlatform.NO_INIT, TestPlatform.SLIM};
-        } else {
+        if (TEST_BINARY) {
             return TestPlatform.values();
+        } else {
+            return new TestPlatform[]{TestPlatform.NATIVE, TestPlatform.ALPINE, TestPlatform.CENTOS, TestPlatform.UBUNTU, TestPlatform.NO_INIT, TestPlatform.SLIM};
         }
     }
 
@@ -477,7 +477,7 @@ public class BourneShellScriptTest {
     }
 
     @Test public void binaryCaching() throws Exception {
-        assumeTrue(!Objects.equals(System.getenv().get("SKIP_BINARY_GENERATION"), "true") && !platform.equals(TestPlatform.UBUNTU_NO_BINARY));
+        assumeTrue(TEST_BINARY && !platform.equals(TestPlatform.UBUNTU_NO_BINARY));
         String os;
         switch (platform) {
             case NATIVE:

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.containsString;
 import org.jenkinsci.test.acceptance.docker.DockerClassRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.AfterClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -67,8 +68,6 @@ import org.jvnet.hudson.test.LoggerRule;
 @RunWith(Parameterized.class)
 public class EncodingTest {
 
-    @Rule public JenkinsRule r = new JenkinsRule();
-
     @Rule public LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
     private static DumbSlave s;
@@ -76,9 +75,13 @@ public class EncodingTest {
     private static FilePath ws;
     private static Launcher launcher;
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass public static void unixAndDocker() throws Exception {
         BourneShellScriptTest.unix();
         BourneShellScriptTest.assumeDocker();
+    }
+
+    @ClassRule public static void setUp() throws Exception {
+        JenkinsRule r = new JenkinsRule();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
         JavaContainer container = new DockerClassRule<>(JavaContainer.class).create();
@@ -92,6 +95,7 @@ public class EncodingTest {
         ws = s.getWorkspaceRoot();
         launcher = s.createLauncher(listener);
     }
+
     private static class DetectCharset extends MasterToSlaveCallable<String, RuntimeException> {
         @Override public String call() throws RuntimeException {
             return Charset.defaultCharset().name();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -51,9 +51,8 @@ import org.apache.commons.io.output.TeeOutputStream;
 import static org.hamcrest.Matchers.containsString;
 import org.jenkinsci.test.acceptance.docker.DockerClassRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -70,6 +69,8 @@ import org.jvnet.hudson.test.LoggerRule;
 public class EncodingTest {
 
     @Rule public LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
+    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public DockerClassRule<JavaContainer> dockerUbuntu = new DockerClassRule<>(JavaContainer.class);
 
     private static DumbSlave s;
     private static StreamTaskListener listener;
@@ -82,10 +83,9 @@ public class EncodingTest {
     }
 
     @Before public void setUp() throws Exception {
-        JenkinsRule r = new JenkinsRule();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
-        JavaContainer container = new DockerClassRule<>(JavaContainer.class).create();
+        JavaContainer container = dockerUbuntu.create();
         SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(Domain.global(), Collections.<Credentials>singletonList(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "test", "test"))));
         SSHLauncher sshLauncher = new SSHLauncher(container.ipBound(22), container.port(22), "test");
         sshLauncher.setJvmOptions("-Dfile.encoding=ISO-8859-1");
@@ -103,7 +103,7 @@ public class EncodingTest {
         }
     }
 
-    @AfterClass public static void tearDown() throws Exception {
+    @After public void tearDown() throws Exception {
         s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -52,6 +52,7 @@ import static org.hamcrest.Matchers.containsString;
 import org.jenkinsci.test.acceptance.docker.DockerClassRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,7 +81,7 @@ public class EncodingTest {
         BourneShellScriptTest.assumeDocker();
     }
 
-    @ClassRule public static void setUp() throws Exception {
+    @Before public static void setUp() throws Exception {
         JenkinsRule r = new JenkinsRule();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -73,17 +73,14 @@ public class EncodingTest {
 
     @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
-    @BeforeClass public static void unixAndDocker() throws Exception {
-        BourneShellScriptTest.unix();
-        BourneShellScriptTest.assumeDocker();
-    }
-
     private static DumbSlave s;
     private static StreamTaskListener listener;
     private static FilePath ws;
     private static Launcher launcher;
 
     @BeforeClass public static void setUp() throws Exception {
+        BourneShellScriptTest.unix();
+        BourneShellScriptTest.assumeDocker();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
         JavaContainer container = dockerUbuntu.create();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -52,7 +52,6 @@ import static org.hamcrest.Matchers.containsString;
 import org.jenkinsci.test.acceptance.docker.DockerClassRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.AfterClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -68,9 +67,9 @@ import org.jvnet.hudson.test.LoggerRule;
 @RunWith(Parameterized.class)
 public class EncodingTest {
 
-    @ClassRule public static JenkinsRule r = new JenkinsRule();
+    @Rule public static JenkinsRule r = new JenkinsRule();
 
-    @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
+    @Rule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
     private static DumbSlave s;
     private static StreamTaskListener listener;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -67,7 +67,7 @@ import org.jvnet.hudson.test.LoggerRule;
 @RunWith(Parameterized.class)
 public class EncodingTest {
 
-    @Rule public static JenkinsRule r = new JenkinsRule();
+    @Rule public JenkinsRule r = new JenkinsRule();
 
     @Rule public LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -73,14 +73,17 @@ public class EncodingTest {
 
     @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
+    @BeforeClass public static void unixAndDocker() throws Exception {
+        BourneShellScriptTest.unix();
+        BourneShellScriptTest.assumeDocker();
+    }
+
     private static DumbSlave s;
     private static StreamTaskListener listener;
     private static FilePath ws;
     private static Launcher launcher;
 
     @BeforeClass public static void setUp() throws Exception {
-        BourneShellScriptTest.unix();
-        BourneShellScriptTest.assumeDocker();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
         JavaContainer container = dockerUbuntu.create();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -51,9 +51,8 @@ import org.apache.commons.io.output.TeeOutputStream;
 import static org.hamcrest.Matchers.containsString;
 import org.jenkinsci.test.acceptance.docker.DockerClassRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
@@ -68,21 +67,19 @@ import org.jvnet.hudson.test.LoggerRule;
 @RunWith(Parameterized.class)
 public class EncodingTest {
 
-    @Rule public LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
-    @Rule public JenkinsRule r = new JenkinsRule();
-    @Rule public DockerClassRule<JavaContainer> dockerUbuntu = new DockerClassRule<>(JavaContainer.class);
+    @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
+    @ClassRule public static JenkinsRule r = new JenkinsRule();
+    @ClassRule public static DockerClassRule<JavaContainer> dockerUbuntu = new DockerClassRule<>(JavaContainer.class);
 
     private static DumbSlave s;
     private static StreamTaskListener listener;
     private static FilePath ws;
     private static Launcher launcher;
 
-    @BeforeClass public static void unixAndDocker() throws Exception {
+    @BeforeClass public static void setUp() throws Exception {
+        s = null;
         BourneShellScriptTest.unix();
         BourneShellScriptTest.assumeDocker();
-    }
-
-    @Before public void setUp() throws Exception {
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
         JavaContainer container = dockerUbuntu.create();
@@ -103,8 +100,11 @@ public class EncodingTest {
         }
     }
 
-    @After public void tearDown() throws Exception {
-        s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
+    @AfterClass public static
+     void tearDown() throws Exception {
+        if (s != null) {
+            s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
+        }
     }
 
     public static final class TestCase {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -72,17 +72,14 @@ public class EncodingTest {
 
     @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
-    @BeforeClass public static void unixAndDocker() throws Exception {
-        BourneShellScriptTest.unix();
-        BourneShellScriptTest.assumeDocker();
-    }
-
     private static DumbSlave s;
     private static StreamTaskListener listener;
     private static FilePath ws;
     private static Launcher launcher;
 
     @BeforeClass public static void setUp() throws Exception {
+        BourneShellScriptTest.unix();
+        BourneShellScriptTest.assumeDocker();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
         JavaContainer container = new DockerClassRule<>(JavaContainer.class).create();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -53,6 +53,7 @@ import org.jenkinsci.test.acceptance.docker.DockerClassRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
@@ -69,8 +70,6 @@ public class EncodingTest {
 
     @ClassRule public static JenkinsRule r = new JenkinsRule();
 
-    @ClassRule public static DockerClassRule<JavaContainer> dockerUbuntu = new DockerClassRule<>(JavaContainer.class);
-
     @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
     @BeforeClass public static void unixAndDocker() throws Exception {
@@ -86,7 +85,7 @@ public class EncodingTest {
     @BeforeClass public static void setUp() throws Exception {
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
-        JavaContainer container = dockerUbuntu.create();
+        JavaContainer container = new DockerClassRule<>(JavaContainer.class).create();
         SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(Domain.global(), Collections.<Credentials>singletonList(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "test", "test"))));
         SSHLauncher sshLauncher = new SSHLauncher(container.ipBound(22), container.port(22), "test");
         sshLauncher.setJvmOptions("-Dfile.encoding=ISO-8859-1");

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -81,7 +81,7 @@ public class EncodingTest {
         BourneShellScriptTest.assumeDocker();
     }
 
-    @Before public static void setUp() throws Exception {
+    @Before public void setUp() throws Exception {
         JenkinsRule r = new JenkinsRule();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -69,7 +69,7 @@ public class EncodingTest {
 
     @Rule public static JenkinsRule r = new JenkinsRule();
 
-    @Rule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
+    @Rule public LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
 
     private static DumbSlave s;
     private static StreamTaskListener listener;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
@@ -52,6 +52,7 @@ public class PowerShellCoreScriptTest {
 
     @BeforeClass
     public static void pwshOrDocker() throws Exception {
+        BourneShellScriptTest.unix();
         checkPwsh();
         if (!pwshExists && new Docker().isAvailable()) {
             assumeDocker();


### PR DESCRIPTION
Currently, when the `generate-binaries` script fails, it does not return a failure code and the entire build process will continue. This is especially important for the unit tests that are assuming the binary is present.

PCT will need to set `SKIP_BINARY_GENERATION=true` in the environment variables. This will skip the docker build, ignore the `binaryCaching` unit test as well as the `UBUNTU_NO_BINARY` test platform