### PR TITLE
[JENKINS-62014] Add support for build step environment filters

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Duse-jenkins-bom

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,10 @@
     <properties>
         <revision>1.35</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.150.1</jenkins.version>
+        <jenkins.version>2.236-rc29908.d71e7c850809</jenkins.version>
         <java.level>8</java.level>
         <binary.src>src/main/go/org/jenkinsci/plugins/durabletask</binary.src>
+        <useBeta>true</useBeta>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <revision>1.35</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.236-rc29908.d71e7c850809</jenkins.version>
+        <jenkins.version>2.248</jenkins.version>
         <java.level>8</java.level>
         <binary.src>src/main/go/org/jenkinsci/plugins/durabletask</binary.src>
         <useBeta>true</useBeta>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>trilead-api</artifactId>
+            <version>1.0.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
             <version>1.30.0</version>
             <scope>test</scope>

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -225,6 +225,9 @@ public final class BourneShellScript extends FileMonitoringTask {
         }
 
         LOGGER.log(Level.FINE, "launching {0}", launcherCmd);
+
+        launcher.prepareFilterRules(getRun(), this);
+
         Launcher.ProcStarter ps = launcher.launch().cmds(launcherCmd).envs(escape(envVars)).pwd(ws).quiet(true);
         if (LAUNCH_DIAGNOSTICS) {
             ps.stdout(listener);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/DurableTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/DurableTask.java
@@ -29,6 +29,7 @@ import hudson.ExtensionPoint;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractDescribableImpl;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -43,6 +44,25 @@ import javax.annotation.Nonnull;
 public abstract class DurableTask extends AbstractDescribableImpl<DurableTask> implements ExtensionPoint {
 
     private static final Logger LOGGER = Logger.getLogger(DurableTask.class.getName());
+
+    /**
+     * Optional information about the run that has triggered this task
+     */
+    protected transient Run<?, ?> run;
+
+    /**
+     * @since TODO
+     */
+    public void setRun(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    /**
+     * @since TODO
+     */
+    public Run<?, ?> getRun() {
+        return run;
+    }
 
     @Override public DurableTaskDescriptor getDescriptor() {
         return (DurableTaskDescriptor) super.getDescriptor();

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -72,6 +72,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.security.MasterToSlaveCallable;
+import jenkins.tasks.filters.EnvVarsFilterableBuilder;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.io.output.CountingOutputStream;
@@ -81,7 +82,7 @@ import org.jenkinsci.remoting.util.IOUtils;
 /**
  * A task which forks some external command and then waits for log and status files to be updated/created.
  */
-public abstract class FileMonitoringTask extends DurableTask {
+public abstract class FileMonitoringTask extends DurableTask implements EnvVarsFilterableBuilder {
 
     private static final Logger LOGGER = Logger.getLogger(FileMonitoringTask.class.getName());
 

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 import hudson.model.TaskListener;
 import java.io.IOException;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
@@ -126,7 +127,9 @@ public final class PowershellScript extends FileMonitoringTask {
                 writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
             }
         }
-        
+
+        launcher.prepareFilterRules(getRun(), this);
+
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         ps.readStdout().readStderr();
         Proc p = ps.start();

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -32,6 +32,7 @@ import hudson.Launcher;
 import hudson.Proc;
 import hudson.model.TaskListener;
 import java.io.IOException;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -75,6 +76,8 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         }
         c.getBatchFile1(ws).write(cmd, "UTF-8");
         c.getBatchFile2(ws).write(script, "UTF-8");
+
+        launcher.prepareFilterRules(getRun(), this);
 
         Launcher.ProcStarter ps = launcher.launch().cmds("cmd", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(escape(envVars)).pwd(ws).quiet(true);
         /* Too noisy, and consumes a thread:


### PR DESCRIPTION
See [JENKINS-62014](https://issues.jenkins-ci.org/browse/JENKINS-62014).

This adds support for global build step environment filters to durable task based pipeline steps.

Downstream from https://github.com/jenkinsci/jenkins/pull/4683.
Upstream from https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/135.