### PR TITLE
Use Windows ACI agents for CI build because they do not have Docker installed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 def builds = [:]
-builds['docker'] = { buildPlugin(platforms: ['docker']) }
-builds['windows'] = {
+builds['linux-with-docker-wrapper'] = { buildPlugin(platforms: ['docker']) }
+builds['windows-wrapper'] = {
     withEnv(['SKIP_DURABLE_TASK_BINARY_GENERATION=true']) {
-        buildPlugin(platforms: ['windows'])
+        buildPlugin(useAci: true, platforms: ['windows'])
     }
 }
 parallel builds


### PR DESCRIPTION
I think that at some point the Windows agents on ci.jenkins.io switched to having Docker for Windows installed on them, which causes issues with tests that use `@ClassRule public static DockerRule` (e.g. `EncodingTest` here) because `DockerRule` just checks if `docker` is available and seems to be initialized before `@beforeClass` methods, but all of the standard images for use with `DockerRule` only work on Linux. Probably we need to update `docker-fixtures` to handle these kinds of issues automatically.

For now at least this should get the CI build passing here.

CC @daniel-beck 