### PR TITLE
[JENKINS-55145] Convert anonymous class into named class to avoid serialization warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,6 @@
-def builds = [:]
-builds['linux-with-docker-wrapper'] = { buildPlugin(platforms: ['docker']) }
-builds['windows-wrapper'] = {
-    withEnv(['SKIP_DURABLE_TASK_BINARY_GENERATION=true']) {
-        buildPlugin(useAci: true, platforms: ['windows'])
-    }
+// TODO: Come up with a way to enable binary generation on Linux but not
+// on Windows without needing to run buildPlugin multiple times to avoid
+// https://github.com/jenkinsci/durable-task-plugin/pull/126#issuecomment-681964838.
+withEnv(['SKIP_DURABLE_TASK_BINARY_GENERATION=true']) {
+  buildPlugin(platforms: ['docker', 'maven-windows'])
 }
-parallel builds


### PR DESCRIPTION
See [JENKINS-55145](https://issues.jenkins-ci.org/browse/JENKINS-55145).

Before this PR, every call to `getOutput` would cause the following to be printed:

```
WARNING: Attempt to (de-)serialize anonymous class org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController$1 in file:/var/lib/jenkins/plugins/durable-task/WEB-INF/lib/durable-task.jar;
see: https://jenkins.io/redirect/serialization-of-anonymous-classes/
```

The anonymous class was only being serialized via remoting so we don't have to worry about maintaining serialization compatibility.