### PR TITLE
Store output persistently

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -138,6 +138,11 @@ public final class BourneShellScript extends FileMonitoringTask {
         capturingOutput = true;
     }
 
+    @Override
+    public void storeOutput(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
     @Override protected FileMonitoringController launchWithCookie(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars, String cookieVariable, String cookieValue) throws IOException, InterruptedException {
         if (script.isEmpty()) {
             listener.getLogger().println("Warning: was asked to run an empty script");
@@ -175,7 +180,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             scriptEncodingCharset = zOSSystemEncodingCharset.name();
         }
 
-        ShellController c = new ShellController(ws,(os == OsType.ZOS));
+        ShellController c = new ShellController(ws, outputFile, (os == OsType.ZOS));
         FilePath shf = c.getScriptFile(ws);
 
         shf.write(script, scriptEncodingCharset);
@@ -333,8 +338,8 @@ public final class BourneShellScript extends FileMonitoringTask {
         /** Caching zOS flag to avoid round trip calls in exitStatus()         */
         private final boolean isZos;
 
-        private ShellController(FilePath ws, boolean zOsFlag) throws IOException, InterruptedException {
-            super(ws);
+        private ShellController(FilePath ws, String outputFile, boolean zOsFlag) throws IOException, InterruptedException {
+            super(ws, outputFile);
             this.isZos = zOsFlag;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/durabletask/DurableTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/DurableTask.java
@@ -70,6 +70,10 @@ public abstract class DurableTask extends AbstractDescribableImpl<DurableTask> i
         throw new UnsupportedOperationException("Capturing of output is not implemented in " + getClass().getName());
     }
 
+    public void storeOutput(String outputFile) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("Storing output to file is not implemented in " + getClass().getName());
+    }
+
     /**
      * Requests that a specified charset be used to transcode process output.
      * The encoding of {@link Controller#writeLog} and {@link Controller#getOutput} is then presumed to be UTF-8.

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -419,7 +419,7 @@ public abstract class FileMonitoringTask extends DurableTask {
          */
         public FilePath getLogFile(FilePath workspace) throws IOException, InterruptedException {
             if (outputFile != null) {
-                return workspace.toComputer().getNode().createPath(outputFile);
+                return new FilePath(workspace.getChannel(), outputFile);
             } else {
                 return controlDir(workspace).child("jenkins-log.txt");
             }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -95,6 +95,8 @@ public abstract class FileMonitoringTask extends DurableTask {
      */
     private @CheckForNull String charset;
 
+    protected String outputFile;
+
     private static String cookieFor(FilePath workspace) {
         return "durable-" + Util.getDigestOf(workspace.getRemote());
     }
@@ -167,6 +169,8 @@ public abstract class FileMonitoringTask extends DurableTask {
          */
         private long lastLocation;
 
+        protected String outputFile;
+
         /** @see FileMonitoringTask#charset */
         private @CheckForNull String charset;
 
@@ -199,6 +203,13 @@ public abstract class FileMonitoringTask extends DurableTask {
                 controlDir = cd.getRemote();
             } else {
                 controlDir = null;
+            }
+        }
+
+        protected FileMonitoringController(FilePath ws, String outputFile) throws IOException, InterruptedException {
+            this(ws);
+            if (outputFile != null) {
+                this.outputFile = ws.child(outputFile).getRemote();
             }
         }
 
@@ -407,7 +418,11 @@ public abstract class FileMonitoringTask extends DurableTask {
          * File in which the stdout/stderr (or, if {@link #captureOutput} is called, just stderr) is written.
          */
         public FilePath getLogFile(FilePath workspace) throws IOException, InterruptedException {
-            return controlDir(workspace).child("jenkins-log.txt");
+            if (outputFile != null) {
+                return workspace.toComputer().getNode().createPath(outputFile);
+            } else {
+                return controlDir(workspace).child("jenkins-log.txt");
+            }
         }
 
         /**

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -71,10 +71,15 @@ public final class PowershellScript extends FileMonitoringTask {
         capturingOutput = true;
     }
 
+    @Override
+    public void storeOutput(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
     @SuppressFBWarnings(value="VA_FORMAT_STRING_USES_NEWLINE", justification="%n from master might be \\n")
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
         List<String> args = new ArrayList<String>();
-        PowershellController c = new PowershellController(ws);
+        PowershellController c = new PowershellController(ws, outputFile);
         
         String cmd;
         if (capturingOutput) {
@@ -157,6 +162,10 @@ public final class PowershellScript extends FileMonitoringTask {
     private static final class PowershellController extends FileMonitoringController {
         private PowershellController(FilePath ws) throws IOException, InterruptedException {
             super(ws);
+        }
+
+        private PowershellController(FilePath ws, String outputFile) throws IOException, InterruptedException {
+            super(ws, outputFile);
         }
         
         public FilePath getPowerShellScriptFile(FilePath ws) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -53,12 +53,17 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         capturingOutput = true;
     }
 
+    @Override
+    public void storeOutput(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
     @SuppressFBWarnings(value="VA_FORMAT_STRING_USES_NEWLINE", justification="%n from master might be \\n")
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
         if (launcher.isUnix()) {
             throw new IOException("Batch scripts can only be run on Windows nodes");
         }
-        BatchController c = new BatchController(ws);
+        BatchController c = new BatchController(ws, outputFile);
 
         String cmd;
         if (capturingOutput) {
@@ -95,6 +100,10 @@ public final class WindowsBatchScript extends FileMonitoringTask {
     private static final class BatchController extends FileMonitoringController {
         private BatchController(FilePath ws) throws IOException, InterruptedException {
             super(ws);
+        }
+
+        private BatchController(FilePath ws, String outputFile) throws IOException, InterruptedException {
+            super(ws, outputFile);
         }
 
         public FilePath getBatchFile1(FilePath ws) throws IOException, InterruptedException {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -317,6 +317,36 @@ public class BourneShellScriptTest {
         c.cleanup(ws);
     }
 
+    @Test public void storeOutput() throws Exception {
+        DurableTask task = new BourneShellScript("echo 42");
+        task.storeOutput("test.log");
+        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        awaitCompletion(c);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
+        assertThat(baos.toString(), is(equalTo("+ echo 42\n42\n")));
+        FilePath logFile = ws.child("test.log");
+        assertThat(logFile.readToString(), is(equalTo("+ echo 42\n42\n")));
+        c.cleanup(ws);
+    }
+
+    @Test public void storeCaptureOutput() throws Exception {
+        DurableTask task = new BourneShellScript("echo 42");
+        task.storeOutput("test.log");
+        task.captureOutput();
+        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        awaitCompletion(c);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
+        assertThat(baos.toString(), is(equalTo("+ echo 42\n")));
+        FilePath logFile = ws.child("test.log");
+        assertThat(logFile.readToString(), is(equalTo("+ echo 42\n")));
+        assertEquals("42\n", new String(c.getOutput(ws, launcher)));
+        c.cleanup(ws);
+    }
+
     @Issue("JENKINS-38381")
     @Test public void watch() throws Exception {
         DurableTask task = new BourneShellScript("set +x; for x in 1 2 3 4 5; do echo $x; sleep 1; done");

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
@@ -221,6 +221,26 @@ public class PowerShellCoreScriptTest {
         c.cleanup(ws);
     }
 
+    @Test public void storeOutput() throws Exception {
+        PowershellScript s = new PowershellScript("Write-Output \"Success\"");
+        s.setPowershellBinary("pwsh");
+        s.storeOutput("test.log");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() == 0);
+        FilePath logFile = ws.child("test.log");
+        if (launcher.isUnix()) {
+            assertEquals("Success\n", logFile.readToString());
+        } else {
+            assertEquals("Success\r\n", logFile.readToString());
+        }
+        c.cleanup(ws);
+    }
+
     @Test public void specialStreams() throws Exception {
         PowershellScript s = new PowershellScript("$VerbosePreference = \"Continue\"; " +
             "$WarningPreference = \"Continue\"; " +

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -201,6 +201,25 @@ public class PowershellScriptTest {
         }
         c.cleanup(ws);
     }
+
+    @Test public void storeOutput() throws Exception {
+        DurableTask task = new PowershellScript("Write-Output \"Success\"");
+        task.storeOutput("test.log");
+        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() == 0);
+        FilePath logFile = ws.child("test.log");
+        if (launcher.isUnix()) {
+            assertEquals("Success\n", logFile.readToString());
+        } else {
+            assertEquals("Success\r\n", logFile.readToString());
+        }
+        c.cleanup(ws);
+    }
     
     @Test public void specialStreams() throws Exception {
         DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; " +

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -121,14 +121,14 @@ public class WindowsBatchScriptTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
-        assertThat(baos.toString(), is(equalTo("42\n")));
+        assertThat(baos.toString(), is(equalTo("42\r\n")));
         FilePath logFile = ws.child("test.log");
-        assertThat(logFile.readToString(), is(equalTo("42\n")));
+        assertThat(logFile.readToString(), is(equalTo("42\r\n")));
         c.cleanup(ws);
     }
 
     @Test public void storeCaptureOutput() throws Exception {
-        DurableTask task = new WindowsBatchScript("echo 42");
+        DurableTask task = new WindowsBatchScript("@echo 42 & @echo 84 1>&2");
         task.storeOutput("test.log");
         task.captureOutput();
         Controller c = task.launch(new EnvVars(), ws, launcher, listener);
@@ -136,10 +136,10 @@ public class WindowsBatchScriptTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
-        assertThat(baos.toString(), is(equalTo("+ echo 42\n")));
+        assertThat(baos.toString(), is(equalTo("84 \r\n")));
         FilePath logFile = ws.child("test.log");
-        assertThat(logFile.readToString(), is(equalTo("+ echo 42\n")));
-        assertEquals("42\n", new String(c.getOutput(ws, launcher)));
+        assertThat(logFile.readToString(), is(equalTo("84 \r\n")));
+        assertEquals("42 \r\n", new String(c.getOutput(ws, launcher)));
         c.cleanup(ws);
     }
 


### PR DESCRIPTION
I was looking for an option to store the output of some long running commands with massive logging (cmake for example) into a file and also to Jenkins' console output.
Tools like warnings-ng need files to work with.
Build failure Analyzer only works with console output to scan for failure reason.

On linux you can use tee to achive this, but on windows there is no command like this.
I tried [TeeStep](https://www.jenkins.io/doc/pipeline/steps/pipeline-utility-steps/#tee-tee-output-to-file) but it causes really high load on master with massive log output.
That caused odd problems like "Cannot contact node: java.lang.InterruptedException" logs and looping log output and jobs were running much longer because logging was too expensive.