### PR TITLE
Add an option to load the PowerShell profile

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -48,6 +48,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 public final class PowershellScript extends FileMonitoringTask {
     private final String script;
     private String powershellBinary = "powershell";
+    private boolean loadProfile;
     private boolean capturingOutput;
     
     @DataBoundConstructor public PowershellScript(String script) {
@@ -61,6 +62,15 @@ public final class PowershellScript extends FileMonitoringTask {
     @DataBoundSetter
     public void setPowershellBinary(String powershellBinary) {
         this.powershellBinary = powershellBinary;
+    }
+
+    public boolean isLoadProfile() {
+        return loadProfile;
+    }
+
+    @DataBoundSetter
+    public void setLoadProfile(boolean loadProfile) {
+        this.loadProfile = loadProfile;
     }
 
     public String getScript() {
@@ -94,9 +104,12 @@ public final class PowershellScript extends FileMonitoringTask {
 
         String powershellArgs;
         if (launcher.isUnix()) {
-            powershellArgs = "-NoProfile -NonInteractive";
+            powershellArgs = "-NonInteractive";
         } else {
-            powershellArgs = "-NoProfile -NonInteractive -ExecutionPolicy Bypass";
+            powershellArgs = "-NonInteractive -ExecutionPolicy Bypass";
+        }
+        if (!loadProfile) {
+            powershellArgs = "-NoProfile " + powershellArgs;
         }
         args.add(powershellBinary);
         args.addAll(Arrays.asList(powershellArgs.split(" ")));

--- a/src/main/resources/org/jenkinsci/plugins/durabletask/PowershellScript/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/durabletask/PowershellScript/config.jelly
@@ -7,4 +7,7 @@
     <f:entry field="powershellBinary" title="Executable">
         <f:select />
     </f:entry>
+    <f:entry field="loadProfile" title="Load Profile">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -265,4 +265,23 @@ public class PowershellScriptTest {
         assertEquals(Integer.valueOf(5), c.exitStatus(ws, launcher, TaskListener.NULL));
         c.cleanup(ws);
     }
+
+    @Test public void checkProfile() throws Exception {
+        PowershellScript s = new PowershellScript("if ((Get-CimInstance Win32_Process -Filter \"ProcessId = $PID\").CommandLine.split(\" \").Contains(\"-NoProfile\")) { exit 0; } else { exit 1; } ");
+
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
+        c.cleanup(ws);
+
+        s.setLoadProfile(true);
+        c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        assertEquals(1, c.exitStatus(ws, launcher, listener).intValue());
+        c.cleanup(ws);
+    }
 }


### PR DESCRIPTION
Hey Team,
I would like to be able to load the PowerShell profile on the agent. This change is a step in that direction.

Please be kind. I ran the unit tests, but I'm not sure this will work, any ideas on how to test this properly?

Cheers, Mark