### PR TITLE
Fix JENKINS-59529 - PowerShell command invocation errors will now fail the pipeline step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -49,7 +49,7 @@ public final class PowershellScript extends FileMonitoringTask {
     private final String script;
     private String powershellBinary = "powershell";
     private boolean capturingOutput;
-    
+
     @DataBoundConstructor public PowershellScript(String script) {
         this.script = script;
     }
@@ -75,10 +75,10 @@ public final class PowershellScript extends FileMonitoringTask {
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
         List<String> args = new ArrayList<String>();
         PowershellController c = new PowershellController(ws);
-        
+
         String cmd;
         if (capturingOutput) {
-            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;", 
+            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;",
                 quote(c.getPowerShellHelperFile(ws)),
                 quote(c.getPowerShellScriptFile(ws)),
                 quote(c.getOutputFile(ws)),
@@ -101,12 +101,12 @@ public final class PowershellScript extends FileMonitoringTask {
         args.add(powershellBinary);
         args.addAll(Arrays.asList(powershellArgs.split(" ")));
         args.addAll(Arrays.asList("-Command", cmd));
-        
+
         String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
                                              "param()\r\n" +
                                              "& %s %s -Command '& ''%s''; exit $LASTEXITCODE;';\r\n" +
                                              "exit $LASTEXITCODE;", powershellBinary, powershellArgs, quote(quote(c.getPowerShellScriptFile(ws))));
-     
+
         // Add an explicit exit to the end of the script so that exit codes are propagated
         // Fix https://issues.jenkins.io/browse/JENKINS-59529?jql=text%20~%20%22powershell%22
         // Wrap script in try/catch in order to propagate PowerShell errors like: command/script not recognized,
@@ -119,14 +119,14 @@ public final class PowershellScript extends FileMonitoringTask {
         // One consequence of leaving the "exit $LASTEXITCODE" is if the last native command in a script exits with
         // a non-zero exit code, the step will fail. That may sound obvious but most PowerShell scripters are not used
         // to that. PowerShell doesn't have the equivalent of "set -e" yet. However, in the context of a build system,
-        // I believe we should err on the side of false negatives instead of false positives. If a scripter does not
+        // I believe we should err on the side of false negatives instead of false positives. If a scripter doesn't
         // want a non-zero exit code to fail the step, they can do the following (PS >= v7) to reset $LASTEXITCODE:
         // whoami -f || $($global:LASTEXITCODE = 0)
         String scriptWithExit = "try { " + script + " } catch { throw }\r\nexit $LASTEXITCODE";
-        
+
         // Copy the helper script from the resources directory into the workspace
         c.getPowerShellHelperFile(ws).copyFrom(getClass().getResource("powershellHelper.ps1"));
-        
+
         if (launcher.isUnix() || "pwsh".equals(powershellBinary)) {
             // There is no need to add a BOM with Open PowerShell / PowerShell Core
             c.getPowerShellScriptFile(ws).write(scriptWithExit, "UTF-8");
@@ -140,7 +140,7 @@ public final class PowershellScript extends FileMonitoringTask {
                 writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
             }
         }
-        
+
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         ps.readStdout().readStderr();
         Proc p = ps.start();
@@ -149,7 +149,7 @@ public final class PowershellScript extends FileMonitoringTask {
 
         return c;
     }
-    
+
     private static String quote(FilePath f) {
         return quote(f.getRemote());
     }
@@ -157,7 +157,7 @@ public final class PowershellScript extends FileMonitoringTask {
     private static String quote(String f) {
         return f.replace("'", "''");
     }
-    
+
     // In order for PowerShell to properly read a script that contains unicode characters the script should have a BOM, but there is no built in support for
     // writing UTF-8 with BOM in Java.  This code writes a UTF-8 BOM before writing the file contents.
     private static void writeWithBom(FilePath f, String contents) throws IOException, InterruptedException {
@@ -172,15 +172,15 @@ public final class PowershellScript extends FileMonitoringTask {
         private PowershellController(FilePath ws) throws IOException, InterruptedException {
             super(ws);
         }
-        
+
         public FilePath getPowerShellScriptFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellScript.ps1");
         }
-        
+
         public FilePath getPowerShellHelperFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellHelper.ps1");
         }
-        
+
         public FilePath getPowerShellWrapperFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellWrapper.ps1");
         }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -49,7 +49,7 @@ public final class PowershellScript extends FileMonitoringTask {
     private final String script;
     private String powershellBinary = "powershell";
     private boolean capturingOutput;
-    
+
     @DataBoundConstructor public PowershellScript(String script) {
         this.script = script;
     }
@@ -75,10 +75,10 @@ public final class PowershellScript extends FileMonitoringTask {
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
         List<String> args = new ArrayList<String>();
         PowershellController c = new PowershellController(ws);
-        
+
         String cmd;
         if (capturingOutput) {
-            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;", 
+            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;",
                 quote(c.getPowerShellHelperFile(ws)),
                 quote(c.getPowerShellScriptFile(ws)),
                 quote(c.getOutputFile(ws)),
@@ -101,18 +101,28 @@ public final class PowershellScript extends FileMonitoringTask {
         args.add(powershellBinary);
         args.addAll(Arrays.asList(powershellArgs.split(" ")));
         args.addAll(Arrays.asList("-Command", cmd));
-        
+
         String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
                                              "param()\r\n" +
                                              "& %s %s -Command '& ''%s''; exit $LASTEXITCODE;';\r\n" +
                                              "exit $LASTEXITCODE;", powershellBinary, powershellArgs, quote(quote(c.getPowerShellScriptFile(ws))));
-     
+
         // Add an explicit exit to the end of the script so that exit codes are propagated
-        String scriptWithExit = script + "\r\nexit $LASTEXITCODE;";
-        
+        // Fix https://issues.jenkins.io/browse/JENKINS-59529?jql=text%20~%20%22powershell%22
+        // Wrap script in try/catch in order to propagate PowerShell errors like: command/script not recognized,
+        // parameter not found, parameter validation failed, etc. In PowerShell, $LASTEXITCODE applies **only** to the
+        // invocation of native apps and is not set when built-in PowerShell commands or script invocation fails.
+        // One consequence of leaving the "exit $LASTEXITCODE" is that any native command in a script that exits
+        // with a non-zero exit code will fail the step. That may sound obvious but most PowerShell scripters are
+        // not used to that. PowerShell doesn't have the equivalent of "set -e" yet. In the context of a build system
+        // I believe we should err on the side of false negatives (instead of false positives). If a scripter does not
+        // want a non-zero exit code to fail the step, they can do the following to reset $LASTEXITCODE:
+        // whoami -f || $($global:LASTEXITCODE = 0)
+        String scriptWithExit = "try { " + script + " } catch { throw }\r\nexit $LASTEXITCODE";
+
         // Copy the helper script from the resources directory into the workspace
         c.getPowerShellHelperFile(ws).copyFrom(getClass().getResource("powershellHelper.ps1"));
-        
+
         if (launcher.isUnix() || "pwsh".equals(powershellBinary)) {
             // There is no need to add a BOM with Open PowerShell / PowerShell Core
             c.getPowerShellScriptFile(ws).write(scriptWithExit, "UTF-8");
@@ -126,7 +136,7 @@ public final class PowershellScript extends FileMonitoringTask {
                 writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
             }
         }
-        
+
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         ps.readStdout().readStderr();
         Proc p = ps.start();
@@ -135,7 +145,7 @@ public final class PowershellScript extends FileMonitoringTask {
 
         return c;
     }
-    
+
     private static String quote(FilePath f) {
         return quote(f.getRemote());
     }
@@ -143,7 +153,7 @@ public final class PowershellScript extends FileMonitoringTask {
     private static String quote(String f) {
         return f.replace("'", "''");
     }
-    
+
     // In order for PowerShell to properly read a script that contains unicode characters the script should have a BOM, but there is no built in support for
     // writing UTF-8 with BOM in Java.  This code writes a UTF-8 BOM before writing the file contents.
     private static void writeWithBom(FilePath f, String contents) throws IOException, InterruptedException {
@@ -158,15 +168,15 @@ public final class PowershellScript extends FileMonitoringTask {
         private PowershellController(FilePath ws) throws IOException, InterruptedException {
             super(ws);
         }
-        
+
         public FilePath getPowerShellScriptFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellScript.ps1");
         }
-        
+
         public FilePath getPowerShellHelperFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellHelper.ps1");
         }
-        
+
         public FilePath getPowerShellWrapperFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellWrapper.ps1");
         }
@@ -175,7 +185,6 @@ public final class PowershellScript extends FileMonitoringTask {
     }
 
     @Extension public static final class DescriptorImpl extends DurableTaskDescriptor {
-
         @Override public String getDisplayName() {
             return Messages.PowershellScript_powershell();
         }
@@ -183,7 +192,5 @@ public final class PowershellScript extends FileMonitoringTask {
         public ListBoxModel doFillPowershellBinary() {
             return new ListBoxModel(new Option("powershell"), new Option("pwsh"));
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -49,7 +49,7 @@ public final class PowershellScript extends FileMonitoringTask {
     private final String script;
     private String powershellBinary = "powershell";
     private boolean capturingOutput;
-
+    
     @DataBoundConstructor public PowershellScript(String script) {
         this.script = script;
     }
@@ -75,10 +75,10 @@ public final class PowershellScript extends FileMonitoringTask {
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
         List<String> args = new ArrayList<String>();
         PowershellController c = new PowershellController(ws);
-
+        
         String cmd;
         if (capturingOutput) {
-            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;",
+            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;", 
                 quote(c.getPowerShellHelperFile(ws)),
                 quote(c.getPowerShellScriptFile(ws)),
                 quote(c.getOutputFile(ws)),
@@ -101,28 +101,32 @@ public final class PowershellScript extends FileMonitoringTask {
         args.add(powershellBinary);
         args.addAll(Arrays.asList(powershellArgs.split(" ")));
         args.addAll(Arrays.asList("-Command", cmd));
-
+        
         String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
                                              "param()\r\n" +
                                              "& %s %s -Command '& ''%s''; exit $LASTEXITCODE;';\r\n" +
                                              "exit $LASTEXITCODE;", powershellBinary, powershellArgs, quote(quote(c.getPowerShellScriptFile(ws))));
-
+     
         // Add an explicit exit to the end of the script so that exit codes are propagated
         // Fix https://issues.jenkins.io/browse/JENKINS-59529?jql=text%20~%20%22powershell%22
         // Wrap script in try/catch in order to propagate PowerShell errors like: command/script not recognized,
         // parameter not found, parameter validation failed, etc. In PowerShell, $LASTEXITCODE applies **only** to the
         // invocation of native apps and is not set when built-in PowerShell commands or script invocation fails.
-        // One consequence of leaving the "exit $LASTEXITCODE" is that any native command in a script that exits
-        // with a non-zero exit code will fail the step. That may sound obvious but most PowerShell scripters are
-        // not used to that. PowerShell doesn't have the equivalent of "set -e" yet. In the context of a build system
-        // I believe we should err on the side of false negatives (instead of false positives). If a scripter does not
-        // want a non-zero exit code to fail the step, they can do the following to reset $LASTEXITCODE:
+        // While you **could** prepend your script with "$ErrorActionPreference = 'Stop'; <script>" to get the step
+        // to fail on a PowerShell error, that is not discoverable resulting in issues like 59529 being submitted.
+        // The problem with setting $ErrorActionPreference before the script is that value propagates into the script
+        // which may not be what the user wants.
+        // One consequence of leaving the "exit $LASTEXITCODE" is if the last native command in a script exits with
+        // a non-zero exit code, the step will fail. That may sound obvious but most PowerShell scripters are not used
+        // to that. PowerShell doesn't have the equivalent of "set -e" yet. However, in the context of a build system,
+        // I believe we should err on the side of false negatives instead of false positives. If a scripter does not
+        // want a non-zero exit code to fail the step, they can do the following (PS >= v7) to reset $LASTEXITCODE:
         // whoami -f || $($global:LASTEXITCODE = 0)
         String scriptWithExit = "try { " + script + " } catch { throw }\r\nexit $LASTEXITCODE";
-
+        
         // Copy the helper script from the resources directory into the workspace
         c.getPowerShellHelperFile(ws).copyFrom(getClass().getResource("powershellHelper.ps1"));
-
+        
         if (launcher.isUnix() || "pwsh".equals(powershellBinary)) {
             // There is no need to add a BOM with Open PowerShell / PowerShell Core
             c.getPowerShellScriptFile(ws).write(scriptWithExit, "UTF-8");
@@ -136,7 +140,7 @@ public final class PowershellScript extends FileMonitoringTask {
                 writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
             }
         }
-
+        
         Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
         ps.readStdout().readStderr();
         Proc p = ps.start();
@@ -145,7 +149,7 @@ public final class PowershellScript extends FileMonitoringTask {
 
         return c;
     }
-
+    
     private static String quote(FilePath f) {
         return quote(f.getRemote());
     }
@@ -153,7 +157,7 @@ public final class PowershellScript extends FileMonitoringTask {
     private static String quote(String f) {
         return f.replace("'", "''");
     }
-
+    
     // In order for PowerShell to properly read a script that contains unicode characters the script should have a BOM, but there is no built in support for
     // writing UTF-8 with BOM in Java.  This code writes a UTF-8 BOM before writing the file contents.
     private static void writeWithBom(FilePath f, String contents) throws IOException, InterruptedException {
@@ -168,15 +172,15 @@ public final class PowershellScript extends FileMonitoringTask {
         private PowershellController(FilePath ws) throws IOException, InterruptedException {
             super(ws);
         }
-
+        
         public FilePath getPowerShellScriptFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellScript.ps1");
         }
-
+        
         public FilePath getPowerShellHelperFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellHelper.ps1");
         }
-
+        
         public FilePath getPowerShellWrapperFile(FilePath ws) throws IOException, InterruptedException {
             return controlDir(ws).child("powershellWrapper.ps1");
         }
@@ -185,6 +189,7 @@ public final class PowershellScript extends FileMonitoringTask {
     }
 
     @Extension public static final class DescriptorImpl extends DurableTaskDescriptor {
+
         @Override public String getDisplayName() {
             return Messages.PowershellScript_powershell();
         }
@@ -192,5 +197,7 @@ public final class PowershellScript extends FileMonitoringTask {
         public ListBoxModel doFillPowershellBinary() {
             return new ListBoxModel(new Option("powershell"), new Option("pwsh"));
         }
+
     }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
@@ -159,6 +159,62 @@ public class PowerShellCoreScriptTest {
         c.cleanup(ws);
     }
 
+    @Test public void invocationCommandNotExistError() throws Exception {
+        PowershellScript s = new PowershellScript("Get-VerbDoesNotExist");
+        s.setPowershellBinary("pwsh");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        assertThat(baos.toString(), containsString("Get-VerbDoesNotExist"));
+        c.cleanup(ws);
+    }
+
+    @Test public void invocationParameterNotExistError() throws Exception {
+        PowershellScript s = new PowershellScript("Get-Date -PARAMDOESNOTEXIST");
+        s.setPowershellBinary("pwsh");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        assertThat(baos.toString(), containsString("parameter cannot be found"));
+        c.cleanup(ws);
+    }
+
+    @Test public void invocationParameterBindingError() throws Exception {
+        PowershellScript s = new PowershellScript("Get-Command -CommandType DOESNOTEXIST");
+        s.setPowershellBinary("pwsh");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        assertThat(baos.toString(), containsString("Cannot bind parameter"));
+        c.cleanup(ws);
+    }
+
+    @Test public void invocationParameterValidationError() throws Exception {
+        PowershellScript s = new PowershellScript("Get-Date -Month 13");
+        s.setPowershellBinary("pwsh");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        assertThat(baos.toString(), containsString("Cannot validate argument"));
+        c.cleanup(ws);
+    }
+
     @Test public void explicitThrow() throws Exception {
         PowershellScript s = new PowershellScript("Write-Output \"Hello, World!\"; throw \"explicit error\";");
         s.setPowershellBinary("pwsh");

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -142,6 +142,53 @@ public class PowershellScriptTest {
         assertTrue(c.exitStatus(ws, launcher, TaskListener.NULL).intValue() == 0);
         c.cleanup(ws);
     }
+
+    @Test public void invocationCommandNotExistError() throws Exception {
+        Controller c = new PowershellScript("Get-VerbDoesNotExist").launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        assertThat(baos.toString(), containsString("Get-VerbDoesNotExist"));
+        c.cleanup(ws);
+    }
+
+    @Test public void invocationParameterNotExistError() throws Exception {
+        Controller c = new PowershellScript("Get-Date -PARAMDOESNOTEXIST").launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        assertThat(baos.toString(), containsString("parameter cannot be found"));
+        c.cleanup(ws);
+    }
+
+    @Test public void invocationParameterBindingError() throws Exception {
+        Controller c = new PowershellScript("Get-Command -CommandType DOESNOTEXIST").launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        assertThat(baos.toString(), containsString("Cannot bind parameter"));
+        c.cleanup(ws);
+    }
+
+    @Test public void invocationParameterValidationError() throws Exception {
+        Controller c = new PowershellScript("Get-Date -Month 15").launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
+        c.cleanup(ws);
+    }
     
     @Test public void explicitThrow() throws Exception {
         DurableTask task = new PowershellScript("Write-Output \"Hello, World!\"; throw \"explicit error\";");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

https://issues.jenkins.io/browse/JENKINS-59529?jql=text%20~%20%22powershell%22

To fix this issue, I wrapped the invoked command in a `try { <user-supplied-command> } catch { throw }` to ensure that script/command not found errors, parameter not found and parameter validation errors will now fail the pipeline step.  This has been particularly painful when we have folks find - via the logs - steps that "pass" yet the log indicates the script never ran because someone typo'd the script name (or a parameter name).