### PR TITLE
use `cmd.exe` when launching the script

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -30,14 +30,19 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Proc;
+import hudson.model.Computer;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.util.logging.Logger;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Runs a Windows batch script.
  */
 public final class WindowsBatchScript extends FileMonitoringTask {
+
+    private final static Logger LOGGER = Logger.getLogger(WindowsBatchScript.class.getName());
+    
     private final String script;
     private boolean capturingOutput;
 
@@ -76,7 +81,12 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         c.getBatchFile1(ws).write(cmd, "UTF-8");
         c.getBatchFile2(ws).write(script, "UTF-8");
 
-        Launcher.ProcStarter ps = launcher.launch().cmds("cmd", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(escape(envVars)).pwd(ws).quiet(true);
+        LOGGER.fine(() -> {
+            Computer computer = ws.toComputer();
+            String computerName = (computer == null) ? "unknown" : (computer.getName() + ":" + computer.getDisplayName());
+            return "Attempting to launch durable batch script on " + computerName + " with environment " + envVars.toString();
+        });
+        Launcher.ProcStarter ps = launcher.launch().cmds("cmd.exe", "/c", "\"\"" + c.getBatchFile1(ws) + "\"\"").envs(escape(envVars)).pwd(ws).quiet(true);
         /* Too noisy, and consumes a thread:
         ps.stdout(listener);
         */


### PR DESCRIPTION
`cmd.exe` is always `cmd.exe` and never `cmd.com` or `cmd.bat` or any other valid `PATH_EXT` so use it to launch the outer process.

Whilst I probably should have fixed the other occurence (used to spawn the innder batch script) I am attempting to diagnose an opaque error and having a difference between the outer and inter script calling is helpful.  (hence the addition of the extra logs also!)


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
