### PR TITLE
Fix parse error on [CmdletBinding()] in PowerShell script and fix parse error not failing the step

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
@@ -159,6 +159,20 @@ public class PowerShellCoreScriptTest {
         c.cleanup(ws);
     }
 
+    @Test public void parseError() throws Exception {
+        PowershellScript s = new PowershellScript("Write-Output \"Hello, World!");
+        s.setPowershellBinary("pwsh");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener) != 0);
+        assertThat(baos.toString(), containsString("string is missing the terminator"));
+        c.cleanup(ws);
+    }
+
     @Test public void invocationCommandNotExistError() throws Exception {
         PowershellScript s = new PowershellScript("Get-VerbDoesNotExist");
         s.setPowershellBinary("pwsh");
@@ -212,6 +226,19 @@ public class PowerShellCoreScriptTest {
         c.writeLog(ws, baos);
         assertTrue(c.exitStatus(ws, launcher, listener).intValue() != 0);
         assertThat(baos.toString(), containsString("Cannot validate argument"));
+        c.cleanup(ws);
+    }
+
+    @Test public void cmdletBindingScriptDoesNotError() throws Exception {
+        PowershellScript s = new PowershellScript("[CmdletBinding()]param([Parameter()][string]$Param1) \"Param1 = $Param1\"");
+        s.setPowershellBinary("pwsh");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertTrue(c.exitStatus(ws, launcher, listener).intValue() == 0);
         c.cleanup(ws);
     }
 


### PR DESCRIPTION
Fixes [Jenkins-65597](https://issues.jenkins.io/browse/JENKINS-65597) which was broken by my first attempt to fix [Jenkins-59529](https://issues.jenkins.io/browse/JENKINS-59529) via PR #131.  Unfortunately the test coverage for the PowerShell step did not cover the issue found in Jenkins-65597.  I've added two new tests to get coverage for that scenario plus ensuring a PowerShell step with a "parse error" will fail.

~First, I want to see the new tests fail first before checking in the code that should fix them (red / green approach).~

The fix removes all changes from powershellScript.ps1 - which resolves the issue with `[CmdletBinding()]` causing a parse error.  This is because certain statements like `[CmdletBinding()]` and `param()` must appear at the top of the script before any other statement including `try`.  The try/catch will be added to powershellWrapper.ps1 which has the added benefit of causing PowerShell step "parse errors" to fail the step.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

P.S. Sorry about the whitespace changes but maybe we should bite the bullet and have any trailing whitespace in the files trimmed otherwise this will keep cropping up?

Is there a way to provide a prerelease version to folks to test out given the "unexpected issue" with the last update?
