### PR TITLE
Fix batch line endings to Windows (CRLF)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -33,6 +33,7 @@ import hudson.Proc;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import org.kohsuke.stapler.DataBoundConstructor;
+import hudson.util.LineEndingConversion;
 
 /**
  * Runs a Windows batch script.
@@ -42,7 +43,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
     private boolean capturingOutput;
 
     @DataBoundConstructor public WindowsBatchScript(String script) {
-        this.script = script;
+        this.script = LineEndingConversion.convertEOL(script, LineEndingConversion.EOLType.Windows);
     }
     
     public String getScript() {


### PR DESCRIPTION
Fixes the same issue with wrong (Unix) line endings in .bat scripts as in [JENKINS-7478](https://issues.jenkins.io/browse/JENKINS-7478) for pipeline `bat` step.
The idea for the fix of `WindowsBatchScript` is taken from https://github.com/jenkinsci/jenkins/pull/1370

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
