### PR TITLE
Properly handle batch scripts that call exit /b after an error

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -62,13 +62,13 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         String cmd;
         if (capturingOutput) {
-            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
+            cmd = String.format("@echo off \r\ncmd /c call \"%s\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getOutputFile(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));
         } else {
-            cmd = String.format("@echo off \r\ncmd /c \"\"%s\"\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
+            cmd = String.format("@echo off \r\ncmd /c call \"%s\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -105,6 +105,17 @@ public class WindowsBatchScriptTest {
         c.cleanup(ws);
     }
 
+    @Test public void exitBCommandAfterError() throws Exception {
+        Controller c = new WindowsBatchScript("cmd /c exit 42\r\nexit /b").launch(new EnvVars(), ws, launcher, listener);
+        while (c.exitStatus(ws, launcher, listener) == null) {
+            Thread.sleep(100);
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertEquals(42, c.exitStatus(ws, launcher, listener).intValue());
+        c.cleanup(ws);
+    }
+
     @Issue("JENKINS-26133")
     @Test public void output() throws Exception {
         DurableTask task = new WindowsBatchScript("@echo 42"); // http://stackoverflow.com/a/8486061/12916

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -75,17 +75,18 @@ public class WindowsBatchScriptTest {
     }
 
     private void testWithPath(String path) throws Exception {
-        Controller c = new WindowsBatchScript("echo hello world").launch(new EnvVars(), ws, launcher, listener);
-        while (c.exitStatus(ws, launcher, listener) == null) {
+        FilePath wsWithPath = ws.child(path);
+        Controller c = new WindowsBatchScript("echo hello world").launch(new EnvVars(), wsWithPath, launcher, listener);
+        while (c.exitStatus(wsWithPath, launcher, listener) == null) {
             Thread.sleep(100);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        c.writeLog(ws, baos);
-        assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher, listener));
+        c.writeLog(wsWithPath, baos);
+        assertEquals(Integer.valueOf(0), c.exitStatus(wsWithPath, launcher, listener));
         String log = baos.toString();
         System.err.print(log);
         assertTrue(log, log.contains("hello world"));
-        c.cleanup(ws);
+        c.cleanup(wsWithPath);
     }
 
     @Issue("JENKINS-27419")


### PR DESCRIPTION
Fixed case when `exit /b` is used to return from `bat` step after an error produces SUCCESS result:
```groovy
node('windows') {
    bat '''
        cmd /c exit 42
        exit /b
    '''
}
```
```bat
Started by user Solovyev, Dmitriy
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] Start of Pipeline
[Pipeline] node
Running on *********** in c:\******\jenkins\workspace\test-exit-b-bat-pipeline
[Pipeline] {
[Pipeline] bat

*************@*********** c:\******\jenkins\workspace\test-exit-b-bat-pipeline>cmd /c exit 42 

*************@*********** c:\******\jenkins\workspace\test-exit-b-bat-pipeline>exit /b 
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```

Such issue in "Freestyle" jobs has been fixed quite long ago in https://github.com/jenkinsci/jenkins/commit/12a83871398ed03a677b8e7bb985786d9ffd9924.

Related to [JENKINS-27419](https://issues.jenkins.io/browse/JENKINS-27419)/https://github.com/jenkinsci/durable-task-plugin/pull/12 and [JENKINS-25678](https://issues.jenkins.io/browse/JENKINS-25678)/https://github.com/jenkinsci/durable-task-plugin/pull/18.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
