### PR TITLE
[JENKINS-27617] Add support for windows binary

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(platforms: ['docker', 'maven-windows'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>51.vb39c166fd9af</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
+            <version>25.v6c906af81ee2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>41.v954ef153d0dc</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
+            <version>45.v7f952d45da76</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>23.v4a2176a89153</version>
+            <version>41.v954ef153d0dc</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>durable-task</artifactId>
-    <version>1.37</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Durable Task Plugin</name>
     <description>Library offering an extension point for processes which can run outside of Jenkins yet be monitored.</description>
@@ -20,7 +20,7 @@
     </licenses>
 
     <properties>
-        <revision>1.37</revision>
+        <revision>1.38</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
@@ -43,7 +43,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>durable-task-1.37</tag>
+        <tag>${scmTag}</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>46.v7b3198932eff</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
+            <version>47.vebb31e9713df</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>48.v01def8e85d7e</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
+            <version>49.v6c3068797bbe</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>47.vebb31e9713df</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
+            <version>48.v01def8e85d7e</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>45.v7f952d45da76</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
+            <version>46.v7b3198932eff</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <revision>1.38</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.150.1</jenkins.version>
+        <jenkins.version>2.249.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -66,6 +66,31 @@
     </dependencies>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+                <version>1.7.26</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.26</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>1.7.26</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+                <version>1.7.26</version>
+            </dependency>
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <revision>1.38</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.249.3</jenkins.version>
+        <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -66,31 +66,6 @@
     </dependencies>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.6</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>1.7.26</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.26</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>1.7.26</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>1.7.26</version>
-            </dependency>
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>lib-durable-task</artifactId>
-            <version>49.v6c3068797bbe</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
+            <version>51.vb39c166fd9af</version> <!-- TODO: Use released version when https://github.com/jenkinsci/lib-durable-task/pull/7 is merged -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>durable-task</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>1.37</version>
     <packaging>hpi</packaging>
     <name>Durable Task Plugin</name>
     <description>Library offering an extension point for processes which can run outside of Jenkins yet be monitored.</description>
@@ -43,7 +43,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>${scmTag}</tag>
+        <tag>durable-task-1.37</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
@@ -121,7 +121,7 @@ public final class AgentInfo implements Serializable {
                 }
             }
 
-            // Note: This will only determine the architecture bits of the JVM. The result will be "32" or "64".
+            // Note: This will only determine the architecture bits of the JVM.
             String bits = System.getProperty("sun.arch.data.model");
             if (bits.equals("64") || bits.equals("32")) {
                 archType += bits;
@@ -136,7 +136,12 @@ public final class AgentInfo implements Serializable {
                 binaryCompatible = false;
             }
 
-            String binaryName = BINARY_PREFIX + binaryVersion + "_" + os.getNameForBinary() + "_" + archType;
+            String extension = "";
+            if (os == OsType.WINDOWS) {
+                extension = ".exe";
+            }
+
+            String binaryName = BINARY_PREFIX + binaryVersion + "_" + os.getNameForBinary() + "_" + archType + extension;
             String binaryPath;
             boolean isCached;
             boolean cachingAvailable;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jenkins.MasterToSlaveFileCallable;
 import org.jenkinsci.remoting.RoleChecker;
 
 import hudson.Platform;
@@ -75,7 +76,7 @@ public final class AgentInfo implements Serializable {
         return cachingAvailable;
     }
 
-    public static final class GetAgentInfo implements FileCallable<AgentInfo> {
+    public static final class GetAgentInfo extends MasterToSlaveFileCallable<AgentInfo> {
         private static final long serialVersionUID = 1L;
         private static final String BINARY_PREFIX = "durable_task_monitor_";
         private static final String CACHE_PATH = "caches/durable-task/";
@@ -159,11 +160,6 @@ public final class AgentInfo implements Serializable {
             AgentInfo agentInfo = new AgentInfo(os, archType, binaryCompatible, binaryPath, cachingAvailable);
             agentInfo.setBinaryAvailability(isCached);
             return agentInfo;
-        }
-
-        @Override
-        public void checkRoles(RoleChecker roleChecker) throws SecurityException {
-
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
@@ -1,0 +1,155 @@
+package org.jenkinsci.plugins.durabletask;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jenkinsci.remoting.RoleChecker;
+
+import hudson.Platform;
+import hudson.FilePath.FileCallable;
+import hudson.remoting.VirtualChannel;
+
+public final class AgentInfo implements Serializable {
+    private static final long serialVersionUID = 7599995179651071957L;
+    private final OsType os;
+    private final String binaryPath;
+    private final String architecture;
+    private boolean binaryCompatible;
+    private boolean binaryCached;
+    private boolean cachingAvailable;
+
+    public enum OsType {
+        // NOTE: changes to these binary names must be mirrored in lib-durable-task
+        DARWIN("darwin"),
+        LINUX("linux"),
+        WINDOWS("windows"),
+        FREEBSD("freebsd"),
+        ZOS("zos");
+
+        private final String binaryName;
+        OsType(final String binaryName) {
+            this.binaryName = binaryName;
+        }
+        public String getNameForBinary() {
+            return binaryName;
+        }
+    }
+
+    public AgentInfo(OsType os, String architecture, boolean binaryCompatible, String binaryPath, boolean cachingAvailable) {
+        this.os = os;
+        this.architecture = architecture;
+        this.binaryPath = binaryPath;
+        this.binaryCompatible = binaryCompatible;
+        this.binaryCached = false;
+        this.cachingAvailable = cachingAvailable;
+    }
+
+    public OsType getOs() {
+        return os;
+    }
+
+    public String getArchitecture() {
+        return architecture;
+    }
+
+    public String getBinaryPath() {
+        return binaryPath;
+    }
+
+    public void setBinaryAvailability(boolean isCached) {
+        binaryCached = isCached;
+    }
+
+    public boolean isBinaryCompatible() {
+        return binaryCompatible;
+    }
+
+    public boolean isBinaryCached() {
+        return binaryCached;
+    }
+
+    public boolean isCachingAvailable() {
+        return cachingAvailable;
+    }
+
+    public static final class GetAgentInfo implements FileCallable<AgentInfo> {
+        private static final long serialVersionUID = 1L;
+        private static final String BINARY_PREFIX = "durable_task_monitor_";
+        private static final String CACHE_PATH = "caches/durable-task/";
+        // Version makes sure we don't use an out-of-date cached binary
+        private String binaryVersion;
+
+        GetAgentInfo(String pluginVersion) {
+            this.binaryVersion = pluginVersion;
+        }
+
+        @Override
+        public AgentInfo invoke(File nodeRoot, VirtualChannel virtualChannel) throws IOException, InterruptedException {
+            OsType os;
+            if (Platform.isDarwin()) {
+                os = OsType.DARWIN;
+            } else if (Platform.current() == Platform.WINDOWS) {
+                os = OsType.WINDOWS;
+            } else if(Platform.current() == Platform.UNIX && System.getProperty("os.name").equals("z/OS")) {
+                os = OsType.ZOS;
+            } else if(Platform.current() == Platform.UNIX && System.getProperty("os.name").equals("FreeBSD")) {
+                os = OsType.FREEBSD;
+            } else {
+                os = OsType.LINUX; // Default Value
+            }
+
+            String arch = System.getProperty("os.arch");
+            boolean binaryCompatible;
+            if ((os != OsType.FREEBSD) && (arch.contains("86") || arch.contains("amd64"))) {
+                binaryCompatible = true;
+            } else {
+                binaryCompatible = false;
+            }
+            String archType = "";
+            if (os == OsType.DARWIN) {
+                if (arch.contains("aarch") || arch.contains("arm")) {
+                    archType = "arm";
+                } else {
+                    archType = "amd"; // Default Value
+                }
+            }
+
+            // Note: This will only determine the architecture bits of the JVM. The result will be "32" or "64".
+            String bits = System.getProperty("sun.arch.data.model");
+            if (bits.equals("64")) {
+                archType += "64";
+            } else {
+                archType += "32"; // Default Value
+            }
+
+            String binaryName = BINARY_PREFIX + binaryVersion + "_" + os.getNameForBinary() + "_" + archType;
+            String binaryPath;
+            boolean isCached;
+            boolean cachingAvailable;
+            try {
+                Path cachePath = Paths.get(nodeRoot.toPath().toString(), CACHE_PATH);
+                Files.createDirectories(cachePath);
+                File binaryFile = new File(cachePath.toFile(), binaryName);
+                binaryPath = binaryFile.toPath().toString();
+                isCached = binaryFile.exists();
+                cachingAvailable = true;
+            } catch (Exception e) {
+                // when the jenkins agent cache path is not accessible
+                binaryPath = binaryName;
+                isCached = false;
+                cachingAvailable = false;
+            }
+            AgentInfo agentInfo = new AgentInfo(os, archType, binaryCompatible, binaryPath, cachingAvailable);
+            agentInfo.setBinaryAvailability(isCached);
+            return agentInfo;
+        }
+
+        @Override
+        public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
@@ -79,7 +79,7 @@ public final class AgentInfo implements Serializable {
         private static final long serialVersionUID = 1L;
         private static final String BINARY_PREFIX = "durable_task_monitor_";
         private static final String CACHE_PATH = "caches/durable-task/";
-        private static final String NOT_SUPPORTED = "NOT_SUPPORTED";
+        private static final String NOT_SUPPORTED = "NOTSUPPORTED";
         // Version makes sure we don't use an out-of-date cached binary
         private String binaryVersion;
 
@@ -94,19 +94,17 @@ public final class AgentInfo implements Serializable {
                 os = OsType.DARWIN;
             } else if (Platform.current() == Platform.WINDOWS) {
                 os = OsType.WINDOWS;
-            } else if (Platform.current() == Platform.UNIX) {
+            } else {
                 String osName = System.getProperty("os.name");
-                if (osName.equals("linux")) {
+                if (osName.equalsIgnoreCase("linux")) {
                     os = OsType.LINUX;
-                } else if (osName.equals("z/OS")) {
+                } else if (osName.equalsIgnoreCase("z/OS")) {
                     os = OsType.ZOS;
-                } else if (osName.equals("FreeBSD")) {
+                } else if (osName.equalsIgnoreCase("FreeBSD")) {
                     os = OsType.FREEBSD;
                 } else {
                     os = OsType.UNKNOWN;
                 }
-            } else {
-                os = OsType.UNKNOWN;
             }
 
             String arch = System.getProperty("os.arch");
@@ -114,8 +112,8 @@ public final class AgentInfo implements Serializable {
             if (os == OsType.DARWIN) {
                 if (arch.contains("aarch") || arch.contains("arm")) {
                     archType = "arm";
-                } else if (arch.contains("amd")) {
-                    archType = "amd"; // Default Value
+                } else if (arch.contains("amd") || arch.contains("x86")) {
+                    archType = "amd";
                 } else {
                     archType = NOT_SUPPORTED;
                 }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -65,7 +65,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean USE_SCRIPT_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".USE_SCRIPT_WRAPPER");
+    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
 
     private static final Logger LOGGER = Logger.getLogger(BourneShellScript.class.getName());
 
@@ -158,7 +158,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         List<String> launcherCmd = null;
         FilePath binary;
-        if (!USE_SCRIPT_WRAPPER && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
+        if (FORCE_BINARY_WRAPPER && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, shell, binary.getRemote(), scriptPath, cookieValue, cookieVariable);
         }
         if (launcherCmd == null) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -65,7 +65,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+    public static boolean USE_SCRIPT_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".USE_SCRIPT_WRAPPER");
 
     private static final Logger LOGGER = Logger.getLogger(BourneShellScript.class.getName());
 
@@ -158,7 +158,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         List<String> launcherCmd = null;
         FilePath binary;
-        if (FORCE_BINARY_WRAPPER && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
+        if (!USE_SCRIPT_WRAPPER && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, shell, binary.getRemote(), scriptPath, cookieValue, cookieVariable);
         }
         if (launcherCmd == null) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -230,8 +230,6 @@ public final class BourneShellScript extends FileMonitoringTask {
         if (!LAUNCH_DIAGNOSTICS) {
             // JENKINS-58290: launch in the background. No need to close stdout/err, binary does not write to them.
             cmd.add("-daemon");
-        } else {
-            cmd.add("-debug");
         }
         return cmd;
     }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -229,11 +229,6 @@ public final class BourneShellScript extends FileMonitoringTask {
         if (capturingOutput) {
             cmd.add("-output=" + outputFile);
         }
-        // TODO: Reminder to test
-//        if (!LAUNCH_DIAGNOSTICS) {
-//            // JENKINS-58290: launch in the background. No need to close stdout/err, binary does not write to them.
-//            cmd.add("-daemon");
-//        }
         // JENKINS-58290: launch in the background. No need to close stdout/err, binary does not write to them.
         cmd.add("-daemon");
         if (LAUNCH_DIAGNOSTICS) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -65,7 +65,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+    public static boolean USE_BINARY_WRAPPER = Boolean.getBoolean(BourneShellScript.class.getName() + ".USE_BINARY_WRAPPER");
 
     private static final Logger LOGGER = Logger.getLogger(BourneShellScript.class.getName());
 
@@ -158,7 +158,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         List<String> launcherCmd = null;
         FilePath binary;
-        if (FORCE_BINARY_WRAPPER && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
+        if (USE_BINARY_WRAPPER && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, shell, binary.getRemote(), scriptPath, cookieValue, cookieVariable);
         }
         if (launcherCmd == null) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -79,6 +79,8 @@ public final class BourneShellScript extends FileMonitoringTask {
      * If requested, we can do this to assist in diagnosis.
      * (For example, if we are unable to write to a workspace due to permissions,
      * we would want to see that error message.)
+     *
+     * For the binary wrapper, this enables the debug flag.
      */
     @SuppressWarnings("FieldMayBeFinal")
     // TODO use SystemProperties if and when unrestricted
@@ -227,9 +229,15 @@ public final class BourneShellScript extends FileMonitoringTask {
         if (capturingOutput) {
             cmd.add("-output=" + outputFile);
         }
-        if (!LAUNCH_DIAGNOSTICS) {
-            // JENKINS-58290: launch in the background. No need to close stdout/err, binary does not write to them.
-            cmd.add("-daemon");
+        // TODO: Reminder to test
+//        if (!LAUNCH_DIAGNOSTICS) {
+//            // JENKINS-58290: launch in the background. No need to close stdout/err, binary does not write to them.
+//            cmd.add("-daemon");
+//        }
+        // JENKINS-58290: launch in the background. No need to close stdout/err, binary does not write to them.
+        cmd.add("-daemon");
+        if (LAUNCH_DIAGNOSTICS) {
+            cmd.add("-debug");
         }
         return cmd;
     }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -28,9 +28,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.FilePath.FileCallable;
 import hudson.Launcher;
-import hudson.Platform;
 import hudson.PluginWrapper;
 import hudson.Proc;
 import hudson.Util;
@@ -41,12 +39,8 @@ import hudson.remoting.VirtualChannel;
 import hudson.tasks.Shell;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.io.File;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -58,7 +52,7 @@ import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.remoting.RoleChecker;
+import org.jenkinsci.plugins.durabletask.AgentInfo.OsType;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -80,23 +74,6 @@ public final class BourneShellScript extends FileMonitoringTask {
     private static final String SYSTEM_DEFAULT_CHARSET = "SYSTEM_DEFAULT";
 
     private static final String LAUNCH_DIAGNOSTICS_PROP = BourneShellScript.class.getName() + ".LAUNCH_DIAGNOSTICS";
-
-    private enum OsType {
-        // NOTE: changes to these binary names must be mirrored in lib-durable-task
-        DARWIN("darwin"),
-        LINUX("linux"),
-        WINDOWS("windows"),
-        FREEBSD("freebsd"),
-        ZOS("zos");
-
-        private final String binaryName;
-        OsType(final String binaryName) {
-            this.binaryName = binaryName;
-        }
-        public String getNameForBinary() {
-            return binaryName;
-        }
-    }
 
     /**
      * Whether to stream stdio from the wrapper script, which should normally not print any.
@@ -163,7 +140,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             throw new IOException("Unable to find durable task plugin");
         }
         String pluginVersion = StringUtils.substringBefore(durablePlugin.getVersion(), "-");
-        AgentInfo agentInfo = nodeRoot.act(new GetAgentInfo(pluginVersion));
+        AgentInfo agentInfo = nodeRoot.act(new AgentInfo.GetAgentInfo(pluginVersion));
 
         OsType os = agentInfo.getOs();
         String scriptEncodingCharset = "UTF-8";
@@ -411,131 +388,6 @@ public final class BourneShellScript extends FileMonitoringTask {
             return Messages.BourneShellScript_bourne_shell();
         }
 
-    }
-
-    private static final class AgentInfo implements Serializable {
-        private static final long serialVersionUID = 7599995179651071957L;
-        private final OsType os;
-        private final String binaryPath;
-        private final String architecture;
-        private boolean binaryCompatible;
-        private boolean binaryCached;
-        private boolean cachingAvailable;
-
-        public AgentInfo(OsType os, String architecture, boolean binaryCompatible, String binaryPath, boolean cachingAvailable) {
-            this.os = os;
-            this.architecture = architecture;
-            this.binaryPath = binaryPath;
-            this.binaryCompatible = binaryCompatible;
-            this.binaryCached = false;
-            this.cachingAvailable = cachingAvailable;
-        }
-
-        public OsType getOs() {
-            return os;
-        }
-
-        public String getArchitecture() {
-            return architecture;
-        }
-
-        public String getBinaryPath() {
-            return binaryPath;
-        }
-
-        public void setBinaryAvailability(boolean isCached) {
-            binaryCached = isCached;
-        }
-
-        public boolean isBinaryCompatible() {
-            return binaryCompatible;
-        }
-
-        public boolean isBinaryCached() {
-            return binaryCached;
-        }
-
-        public boolean isCachingAvailable() {
-            return cachingAvailable;
-        }
-    }
-
-    private static final class GetAgentInfo implements FileCallable<AgentInfo> {
-        private static final long serialVersionUID = 1L;
-        private static final String BINARY_PREFIX = "durable_task_monitor_";
-        private static final String CACHE_PATH = "caches/durable-task/";
-        // Version makes sure we don't use an out-of-date cached binary
-        private String binaryVersion;
-
-        GetAgentInfo(String pluginVersion) {
-            this.binaryVersion = pluginVersion;
-        }
-
-        @Override
-        public AgentInfo invoke(File nodeRoot, VirtualChannel virtualChannel) throws IOException, InterruptedException {
-            OsType os;
-            if (Platform.isDarwin()) {
-                os = OsType.DARWIN;
-            } else if (Platform.current() == Platform.WINDOWS) {
-                os = OsType.WINDOWS;
-            } else if(Platform.current() == Platform.UNIX && System.getProperty("os.name").equals("z/OS")) {
-                os = OsType.ZOS;
-            } else if(Platform.current() == Platform.UNIX && System.getProperty("os.name").equals("FreeBSD")) {
-                os = OsType.FREEBSD;
-            } else {
-                os = OsType.LINUX; // Default Value
-            }
-
-            String arch = System.getProperty("os.arch");
-            boolean binaryCompatible;
-            if ((os != OsType.FREEBSD) && (arch.contains("86") || arch.contains("amd64"))) {
-                binaryCompatible = true;
-            } else {
-                binaryCompatible = false;
-            }
-            String archType = "";
-            if (os == OsType.DARWIN) {
-                if (arch.contains("aarch") || arch.contains("arm")) {
-                    archType = "arm";
-                } else {
-                    archType = "amd"; // Default Value
-                }
-            }
-
-            // Note: This will only determine the architecture bits of the JVM. The result will be "32" or "64".
-            String bits = System.getProperty("sun.arch.data.model");
-            if (bits.equals("64")) {
-                archType += "64";
-            } else {
-                archType += "32"; // Default Value
-            }
-
-            String binaryName = BINARY_PREFIX + binaryVersion + "_" + os.getNameForBinary() + "_" + archType;
-            String binaryPath;
-            boolean isCached;
-            boolean cachingAvailable;
-            try {
-                Path cachePath = Paths.get(nodeRoot.toPath().toString(), CACHE_PATH);
-                Files.createDirectories(cachePath);
-                File binaryFile = new File(cachePath.toFile(), binaryName);
-                binaryPath = binaryFile.toPath().toString();
-                isCached = binaryFile.exists();
-                cachingAvailable = true;
-            } catch (Exception e) {
-                // when the jenkins agent cache path is not accessible
-                binaryPath = binaryName;
-                isCached = false;
-                cachingAvailable = false;
-            }
-            AgentInfo agentInfo = new AgentInfo(os, archType, binaryCompatible, binaryPath, cachingAvailable);
-            agentInfo.setBinaryAvailability(isCached);
-            return agentInfo;
-        }
-
-        @Override
-        public void checkRoles(RoleChecker roleChecker) throws SecurityException {
-
-        }
     }
 
     private static final class getIBMzOsEncoding extends MasterToSlaveCallable<String,RuntimeException> {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -188,7 +188,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         String outputFile = c.getOutputFile(ws).getRemote();
         String controlDirPath = c.controlDir(ws).getRemote();
 
-                List<String> cmd = new ArrayList<>();
+        List<String> cmd = new ArrayList<>();
         cmd.add(binaryPath);
         cmd.add("-controldir=" + controlDirPath);
         cmd.add("-result=" + resultFile);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -30,6 +30,8 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.init.Terminator;
+import hudson.model.Computer;
+import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.DaemonThreadFactory;
@@ -86,6 +88,8 @@ public abstract class FileMonitoringTask extends DurableTask {
     private static final Logger LOGGER = Logger.getLogger(FileMonitoringTask.class.getName());
 
     private static final String COOKIE = "JENKINS_SERVER_COOKIE";
+
+    protected static final String BINARY_RESOURCE_PREFIX = "/io/jenkins/plugins/lib-durable-task/durable_task_monitor_";
 
     /** Value of {@link #charset} used to mean the node’s system default. */
     private static final String SYSTEM_DEFAULT_CHARSET = "SYSTEM_DEFAULT";
@@ -146,6 +150,23 @@ public abstract class FileMonitoringTask extends DurableTask {
         }
         return m;
     }
+
+    protected FilePath getNodeRoot(FilePath workspace) throws IOException {
+        Computer computer = workspace.toComputer();
+        if (computer == null) {
+            throw new IOException("Unable to retrieve computer for workspace");
+        }
+        Node node = computer.getNode();
+        if (node == null) {
+            throw new IOException("Unable to retrieve node for workspace");
+        }
+        FilePath nodeRoot = node.getRootPath();
+        if (nodeRoot == null) {
+            throw new IOException("Unable to retrieve root path of node");
+        }
+        return nodeRoot;
+    }
+
 
     /**
      * Tails a log file and watches for an exit status file.

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -95,10 +95,6 @@ public abstract class FileMonitoringTask extends DurableTask {
 
     protected static final String BINARY_RESOURCE_PREFIX = "/io/jenkins/plugins/lib-durable-task/durable_task_monitor_";
 
-    // Tuning for windows binary testing. This gives the binary a chance to release resources before cleanup happens.
-    private static final int MAX_CLEANUP_TRIES = 6;
-    private static final int MS_BETWEEN_RETRIES = 500;
-
     /** Value of {@link #charset} used to mean the node’s system default. */
     private static final String SYSTEM_DEFAULT_CHARSET = "SYSTEM_DEFAULT";
 
@@ -450,17 +446,7 @@ public abstract class FileMonitoringTask extends DurableTask {
         }
 
         @Override public void cleanup(FilePath workspace) throws IOException, InterruptedException {
-            for (int i = 0; i < MAX_CLEANUP_TRIES; i++) {
-                try {
-                    controlDir(workspace).deleteRecursive();
-                    break;
-                } catch (IOException e) {
-                    if (e.getMessage().contains("Unable to delete")) {
-                        Thread.sleep(MS_BETWEEN_RETRIES);
-                        continue;
-                    }
-                }
-            }
+            controlDir(workspace).deleteRecursive();
             if (cleanupList != null) {
                 cleanupList.stream().forEach(IOUtils::closeQuietly);
             }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -248,9 +248,9 @@ public final class PowershellScript extends FileMonitoringTask {
      */
     private static String generateScriptWrapper(String powershellBinary, List<String> powershellArgs, FilePath powerShellScriptFile) {
         return String.format(
-                "[CmdletBinding()]\r%n" +
-                "param()\r%n" +
-                "& %s %s -Command '& {try {& ''%s''} catch {throw}; exit $LASTEXITCODE}'\r%n" +
+                "[CmdletBinding()]\r\n" +
+                "param()\r\n" +
+                "& %s %s -Command '& {try {& ''%s''} catch {throw}; exit $LASTEXITCODE}'\r\n" +
                 "exit $LASTEXITCODE",
                 powershellBinary, String.join(" ", powershellArgs), quote(quote(powerShellScriptFile)));
     }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -56,7 +56,7 @@ import javax.annotation.Nonnull;
 public final class PowershellScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(PowershellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+    public static boolean USE_BINARY_WRAPPER = Boolean.getBoolean(PowershellScript.class.getName() + ".USE_BINARY_WRAPPER");
 
     private final String script;
     private String powershellBinary = "powershell";
@@ -132,7 +132,7 @@ public final class PowershellScript extends FileMonitoringTask {
         } else {
             pwshLinux = false;
         }
-        if (FORCE_BINARY_WRAPPER && !pwshLinux && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
+        if (USE_BINARY_WRAPPER && !pwshLinux && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, binary.getRemote(), c.getPowerShellScriptFile(ws).getRemote(), powershellArgs);
             if (!usesBom) {
                 // There is no need to add a BOM with Open PowerShell / PowerShell Core

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -56,7 +56,7 @@ import javax.annotation.Nonnull;
 public final class PowershellScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(PowershellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+    public static boolean USE_SCRIPT_WRAPPER = Boolean.getBoolean(PowershellScript.class.getName() + ".USE_SCRIPT_WRAPPER");
 
     private final String script;
     private String powershellBinary = "powershell";
@@ -132,7 +132,7 @@ public final class PowershellScript extends FileMonitoringTask {
         } else {
             pwshLinux = false;
         }
-        if (FORCE_BINARY_WRAPPER && !pwshLinux && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
+        if (!USE_SCRIPT_WRAPPER && !pwshLinux && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, binary.getRemote(), c.getPowerShellScriptFile(ws).getRemote(), powershellArgs);
             if (!usesBom) {
                 // There is no need to add a BOM with Open PowerShell / PowerShell Core

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -129,8 +129,17 @@ public final class PowershellScript extends FileMonitoringTask {
             usesBom = false;
         }
 
-            List<String> launcherCmd = null;
+        List<String> launcherCmd = null;
+        boolean useBinaryWrapper = false;
         if (FORCE_BINARY_WRAPPER && agentInfo.isBinaryCompatible()) {
+            // Binary does not support pwsh on linux
+            if ((agentInfo.getOs() == AgentInfo.OsType.LINUX) && powershellBinary.equals("pwsh")) {
+                useBinaryWrapper = false;
+            } else {
+                useBinaryWrapper = true;
+            }
+        }
+        if (useBinaryWrapper) {
             FilePath controlDir = c.controlDir(ws);
             FilePath binary;
             if (agentInfo.isCachingAvailable()) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -228,17 +228,17 @@ public final class PowershellScript extends FileMonitoringTask {
         String cmd;
         if (capturingOutput) {
             cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;",
-                    quote(c.getPowerShellHelperFile(ws)),
-                    quote(c.getPowerShellScriptFile(ws)),
-                    quote(c.getOutputFile(ws)),
-                    quote(c.getLogFile(ws)),
-                    quote(c.getResultFile(ws)));
+                quote(c.getPowerShellHelperFile(ws)),
+                quote(c.getPowerShellScriptFile(ws)),
+                quote(c.getOutputFile(ws)),
+                quote(c.getLogFile(ws)),
+                quote(c.getResultFile(ws)));
         } else {
             cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -LogFile '%s' -ResultFile '%s';",
-                    quote(c.getPowerShellHelperFile(ws)),
-                    quote(c.getPowerShellWrapperFile(ws)),
-                    quote(c.getLogFile(ws)),
-                    quote(c.getResultFile(ws)));
+                quote(c.getPowerShellHelperFile(ws)),
+                quote(c.getPowerShellWrapperFile(ws)),
+                quote(c.getLogFile(ws)),
+                quote(c.getResultFile(ws)));
         }
 
         args.add(powershellBinary);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -273,7 +273,6 @@ public final class PowershellScript extends FileMonitoringTask {
      * Same motivation as {@link PowershellScript#generateScriptWrapper(String, List, FilePath)}, only for the binary-based launcher
      */
     private static String generateCommandWrapper(String scriptPath, boolean capturingOutput, String outputPath, boolean usesBom, String tempPath) {
-        String encoding = usesBom ? "UTF8" : "utf8NoBOM";
         String wrapper;
         if (capturingOutput) {
             String output = usesBom ? tempPath : outputPath;
@@ -286,16 +285,16 @@ public final class PowershellScript extends FileMonitoringTask {
             // This is because Powershell automatically redirects the non-error streams to the success stream when running -File or -Command.
             // Caution: Do NOT put a space after any commas or else the binary will parse it as a separate argument
             wrapper = String.format(
-                    "[Console]::OutputEncoding = [Text.Encoding]::%s; [Console]::InputEncoding = [System.Text.Encoding]::%s; " +
+                    "[Console]::OutputEncoding = [Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8; " +
                     "& {try {& \\\"%s\\\" | Out-File -FilePath \\\"%s\\\"} catch {throw}%s" +
                     "exit $LASTEXITCODE}",
-                    encoding, encoding, scriptPath, output, finallyString);
+                    scriptPath, output, finallyString);
         } else {
             wrapper = String.format(
-                    "[Console]::OutputEncoding = [Text.Encoding]::%s; [Console]::InputEncoding = [System.Text.Encoding]::%s; " +
+                    "[Console]::OutputEncoding = [Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8; " +
                     "& {try {& \\\"%s\\\"} catch {throw}; " +
                     "exit $LASTEXITCODE}",
-                    encoding, encoding, scriptPath);
+                    scriptPath);
 
         }
         return wrapper;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -275,7 +275,7 @@ public final class PowershellScript extends FileMonitoringTask {
                 "param()\r\n" +
                 "& %s %s -Command '& {try {& ''%s''} catch {throw}; exit $LASTEXITCODE}'\r\n" +
                 "exit $LASTEXITCODE",
-                powershellBinary, powershellArgs, quote(quote(powerShellScriptFile)));
+                powershellBinary, String.join(" ", powershellArgs), quote(quote(powerShellScriptFile)));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -192,9 +192,7 @@ public final class PowershellScript extends FileMonitoringTask {
 
         }
 
-//        LOGGER.log(Level.FINE, "launching {0}", launcherCmd);
-        // TODO: REMOVE
-        LOGGER.log(Level.INFO, "launching {0}", launcherCmd);
+        LOGGER.log(Level.FINE, "launching {0}", launcherCmd);
         Launcher.ProcStarter ps = launcher.launch().cmds(launcherCmd).envs(escape(envVars)).pwd(ws).quiet(true);
         ps.readStdout().readStderr();  // TODO see BourneShellScript
         Proc p = ps.start();

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -133,7 +133,7 @@ public final class PowershellScript extends FileMonitoringTask {
         boolean useBinaryWrapper = false;
         if (FORCE_BINARY_WRAPPER && agentInfo.isBinaryCompatible()) {
             // Binary does not support pwsh on linux
-            if ((agentInfo.getOs() == AgentInfo.OsType.LINUX) && powershellBinary.equals("pwsh")) {
+            if ((agentInfo.getOs() == AgentInfo.OsType.LINUX) && "pwsh".equals(powershellBinary)) {
                 useBinaryWrapper = false;
             } else {
                 useBinaryWrapper = true;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -56,7 +56,7 @@ import javax.annotation.Nonnull;
 public final class PowershellScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean USE_SCRIPT_WRAPPER = Boolean.getBoolean(PowershellScript.class.getName() + ".USE_SCRIPT_WRAPPER");
+    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(PowershellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
 
     private final String script;
     private String powershellBinary = "powershell";
@@ -132,7 +132,7 @@ public final class PowershellScript extends FileMonitoringTask {
         } else {
             pwshLinux = false;
         }
-        if (!USE_SCRIPT_WRAPPER && !pwshLinux && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
+        if (FORCE_BINARY_WRAPPER && !pwshLinux && (binary = requestBinary(nodeRoot, agentInfo, ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, binary.getRemote(), c.getPowerShellScriptFile(ws).getRemote(), powershellArgs);
             if (!usesBom) {
                 // There is no need to add a BOM with Open PowerShell / PowerShell Core

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -25,31 +25,54 @@
 package org.jenkinsci.plugins.durabletask;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Proc;
-import hudson.Launcher;
+import hudson.*;
 import hudson.util.ListBoxModel;
 import hudson.util.ListBoxModel.Option;
+
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import hudson.model.TaskListener;
 import java.io.IOException;
+
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
 
 /**
  * Runs a Powershell script
  */
 public final class PowershellScript extends FileMonitoringTask {
+    @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
+    @Restricted(NoExternalUse.class)
+    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(PowershellScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+
     private final String script;
     private String powershellBinary = "powershell";
     private boolean loadProfile;
     private boolean capturingOutput;
+    /* Byte-Order-Mark for UTF8 files. Powershell does not properly recognize UTF8 files without a BOM */
+    private static final String BOM = "\ufeff";
+    private static final Logger LOGGER = Logger.getLogger(PowershellScript.class.getName());
+    private static final String LAUNCH_DIAGNOSTICS_PROP = PowershellScript.class.getName() + ".LAUNCH_DIAGNOSTICS";
+
+    /**
+     * Enables the debug flag for the binary wrapper.
+     */
+    @SuppressWarnings("FieldMayBeFinal")
+    // TODO use SystemProperties if and when unrestricted
+    private static boolean LAUNCH_DIAGNOSTICS = Boolean.getBoolean(LAUNCH_DIAGNOSTICS_PROP);
 
     @DataBoundConstructor public PowershellScript(String script) {
         this.script = script;
@@ -83,86 +106,162 @@ public final class PowershellScript extends FileMonitoringTask {
 
     @SuppressFBWarnings(value="VA_FORMAT_STRING_USES_NEWLINE", justification="%n from master might be \\n")
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
-        List<String> args = new ArrayList<String>();
+        FilePath nodeRoot = getNodeRoot(ws);
+        final Jenkins jenkins = Jenkins.get();
+        PluginWrapper durablePlugin = jenkins.getPluginManager().getPlugin("durable-task");
+        if (durablePlugin == null) {
+            throw new IOException("Unable to find durable task plugin");
+        }
+        String pluginVersion = StringUtils.substringBefore(durablePlugin.getVersion(), "-");
+        AgentInfo agentInfo = nodeRoot.act(new AgentInfo.GetAgentInfo(pluginVersion));
+
         PowershellController c = new PowershellController(ws);
 
-        String cmd;
-        if (capturingOutput) {
-            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;",
-                quote(c.getPowerShellHelperFile(ws)),
-                quote(c.getPowerShellScriptFile(ws)),
-                quote(c.getOutputFile(ws)),
-                quote(c.getLogFile(ws)),
-                quote(c.getResultFile(ws)));
-        } else {
-            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -LogFile '%s' -ResultFile '%s';",
-                quote(c.getPowerShellHelperFile(ws)),
-                quote(c.getPowerShellWrapperFile(ws)),
-                quote(c.getLogFile(ws)),
-                quote(c.getResultFile(ws)));
-        }
-
-        String powershellArgs;
-        if (launcher.isUnix()) {
-            powershellArgs = "-NonInteractive";
-        } else {
-            powershellArgs = "-NonInteractive -ExecutionPolicy Bypass";
-        }
+        List<String> powershellArgs = new ArrayList<>();
         if (!loadProfile) {
-            powershellArgs = "-NoProfile " + powershellArgs;
+            powershellArgs.add("-NoProfile");
         }
-        args.add(powershellBinary);
-        args.addAll(Arrays.asList(powershellArgs.split(" ")));
-        args.addAll(Arrays.asList("-Command", cmd));
-
-        // Fix https://issues.jenkins.io/browse/JENKINS-59529
-        // Fix https://issues.jenkins.io/browse/JENKINS-65597
-        // Wrap invocation of powershellScript.ps1 in a try/catch in order to propagate PowerShell errors like:
-        // command/script not recognized, parameter not found, parameter validation failed, parse errors, etc. In
-        // PowerShell, $LASTEXITCODE applies **only** to the invocation of native apps and is not set when built-in
-        // PowerShell commands or script invocation fails.
-        // While you **could** prepend your script with "$ErrorActionPreference = 'Stop'; <script>" to get the step
-        // to fail on a PowerShell error, that is not discoverable resulting in issues like 59529 being submitted.
-        // The problem with setting $ErrorActionPreference before the script is that value propagates into the script
-        // which may not be what the user wants.
-        // One consequence of leaving the "exit $LASTEXITCODE" is if the last native command in a script exits with
-        // a non-zero exit code, the step will fail. That may sound obvious but most PowerShell scripters are not used
-        // to that. PowerShell doesn't have the equivalent of "set -e" yet. However, in the context of a build system,
-        // I believe we should err on the side of false negatives instead of false positives. If a scripter doesn't
-        // want a non-zero exit code to fail the step, they can do the following (PS >= v7) to reset $LASTEXITCODE:
-        // whoami -f || $($global:LASTEXITCODE = 0)
-        String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
-                                             "param()\r\n" +
-                                             "& %s %s -Command '& {try {& ''%s''} catch {throw}; exit $LASTEXITCODE}'\r\n" +
-                                             "exit $LASTEXITCODE", powershellBinary, powershellArgs, quote(quote(c.getPowerShellScriptFile(ws))));
-
-        // Add an explicit exit to the end of the script so that exit codes are propagated
-        String scriptWithExit = script + "\r\nexit $LASTEXITCODE";
-
-        // Copy the helper script from the resources directory into the workspace
-        c.getPowerShellHelperFile(ws).copyFrom(getClass().getResource("powershellHelper.ps1"));
-
-        if (launcher.isUnix() || "pwsh".equals(powershellBinary)) {
-            // There is no need to add a BOM with Open PowerShell / PowerShell Core
-            c.getPowerShellScriptFile(ws).write(scriptWithExit, "UTF-8");
-            if (!capturingOutput) {
-                c.getPowerShellWrapperFile(ws).write(scriptWrapper, "UTF-8");
-            }
-        } else {
-            // Write the Windows PowerShell scripts out with a UTF8 BOM
-            writeWithBom(c.getPowerShellScriptFile(ws), scriptWithExit);
-            if (!capturingOutput) {
-                writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
-            }
+        powershellArgs.add("-NonInteractive");
+        if (!launcher.isUnix()) {
+            powershellArgs.addAll(Arrays.asList("-ExecutionPolicy", "Bypass"));
         }
 
-        Launcher.ProcStarter ps = launcher.launch().cmds(args).envs(escape(envVars)).pwd(ws).quiet(true);
-        ps.readStdout().readStderr();
+        List<String> launcherCmd = null;
+        if (FORCE_BINARY_WRAPPER && agentInfo.isBinaryCompatible()) {
+            FilePath controlDir = c.controlDir(ws);
+            FilePath binary;
+            if (agentInfo.isCachingAvailable()) {
+                binary = nodeRoot.child(agentInfo.getBinaryPath());
+            } else {
+                binary = controlDir.child(agentInfo.getBinaryPath());
+            }
+            String resourcePath = BINARY_RESOURCE_PREFIX + agentInfo.getOs().getNameForBinary() + "_" + agentInfo.getArchitecture() + ".exe";
+            try (InputStream binaryStream = BourneShellScript.class.getResourceAsStream(resourcePath)) {
+                if (binaryStream != null) {
+                    if (!agentInfo.isCachingAvailable() || !agentInfo.isBinaryCached()) {
+                        binary.copyFrom(binaryStream);
+                    }
+                    String scriptWrapper = String.format("%s[CmdletBinding()]\r\n" +
+                            "param()\r\n" +
+                            "& %s %s -Command '[Console]::OutputEncoding = [Text.Encoding]::UTF8; & {try {& ''%s''} catch {throw}; exit $LASTEXITCODE} '\r\n" +
+                            "exit $LASTEXITCODE", BOM, powershellBinary, String.join(" ", powershellArgs), c.getPowerShellScriptFile(ws).getRemote());
+
+                    launcherCmd = binaryLauncherCmd(c, ws, controlDir.getRemote(), binary.getRemote(), c.getPowerShellWrapperFile(ws).getRemote(), powershellArgs);
+                    c.getPowerShellScriptFile(ws).write(BOM + script, "UTF-8");
+                    c.getPowerShellWrapperFile(ws).write(scriptWrapper, "UTF-8");
+                }
+            }
+        }
+        if (launcherCmd == null) {
+            launcherCmd = scriptLauncherCmd(c, ws, powershellArgs);
+
+            // Fix https://issues.jenkins.io/browse/JENKINS-59529
+            // Fix https://issues.jenkins.io/browse/JENKINS-65597
+            // Wrap invocation of powershellScript.ps1 in a try/catch in order to propagate PowerShell errors like:
+            // command/script not recognized, parameter not found, parameter validation failed, parse errors, etc. In
+            // PowerShell, $LASTEXITCODE applies **only** to the invocation of native apps and is not set when built-in
+            // PowerShell commands or script invocation fails.
+            // While you **could** prepend your script with "$ErrorActionPreference = 'Stop'; <script>" to get the step
+            // to fail on a PowerShell error, that is not discoverable resulting in issues like 59529 being submitted.
+            // The problem with setting $ErrorActionPreference before the script is that value propagates into the script
+            // which may not be what the user wants.
+            // One consequence of leaving the "exit $LASTEXITCODE" is if the last native command in a script exits with
+            // a non-zero exit code, the step will fail. That may sound obvious but most PowerShell scripters are not used
+            // to that. PowerShell doesn't have the equivalent of "set -e" yet. However, in the context of a build system,
+            // I believe we should err on the side of false negatives instead of false positives. If a scripter doesn't
+            // want a non-zero exit code to fail the step, they can do the following (PS >= v7) to reset $LASTEXITCODE:
+            // whoami -f || $($global:LASTEXITCODE = 0)
+            String scriptWrapper = String.format("[CmdletBinding()]\r\n" +
+                    "param()\r\n" +
+                    "& %s %s -Command '& {try {& ''%s''} catch {throw}; exit $LASTEXITCODE}'\r\n" +
+                    "exit $LASTEXITCODE", powershellBinary, powershellArgs, quote(quote(c.getPowerShellScriptFile(ws))));
+
+            // Add an explicit exit to the end of the script so that exit codes are propagated
+            String scriptWithExit = script + "\r\nexit $LASTEXITCODE";
+
+            // Copy the helper script from the resources directory into the workspace
+            c.getPowerShellHelperFile(ws).copyFrom(getClass().getResource("powershellHelper.ps1"));
+
+            if (launcher.isUnix() || "pwsh".equals(powershellBinary)) {
+                // There is no need to add a BOM with Open PowerShell / PowerShell Core
+                c.getPowerShellScriptFile(ws).write(scriptWithExit, "UTF-8");
+                if (!capturingOutput) {
+                    c.getPowerShellWrapperFile(ws).write(scriptWrapper, "UTF-8");
+                }
+            } else {
+                // Write the Windows PowerShell scripts out with a UTF8 BOM
+                writeWithBom(c.getPowerShellScriptFile(ws), scriptWithExit);
+                if (!capturingOutput) {
+                    writeWithBom(c.getPowerShellWrapperFile(ws), scriptWrapper);
+                }
+            }
+
+        }
+
+//        LOGGER.log(Level.FINE, "launching {0}", launcherCmd);
+        // TODO: REMOVE
+        LOGGER.log(Level.INFO, "launching {0}", launcherCmd);
+        Launcher.ProcStarter ps = launcher.launch().cmds(launcherCmd).envs(escape(envVars)).pwd(ws).quiet(true);
+        ps.readStdout().readStderr();  // TODO see BourneShellScript
         Proc p = ps.start();
         c.registerForCleanup(p.getStdout());
         c.registerForCleanup(p.getStderr());
 
         return c;
+    }
+
+    // TODO: REMOVE
+    // launcher -daemon=true -executable=powershell -args="-NoProfile,-NonInteractive,-ExecutionPolicy,Bypass,-File,path with space\test.ps1" -log=logging.txt -result=result.txt -controldir=. -output=output.txt -debug
+    @Nonnull
+    private List<String> binaryLauncherCmd(PowershellController c, FilePath ws, String controlDirPath, String binaryPath, String scriptPath, List<String> powershellArgs) throws IOException, InterruptedException {
+        String logFile = c.getLogFile(ws).getRemote();
+        String resultFile = c.getResultFile(ws).getRemote();
+        String outputFile = c.getOutputFile(ws).getRemote();
+
+        // TODO: convert powershell args to string with comma
+        String argPrefix = String.join(",", powershellArgs);
+        List<String> cmd = new ArrayList<>();
+        cmd.add(binaryPath);
+        cmd.add("-daemon");
+        cmd.add("-executable=powershell");
+//        cmd.add("-args=-NoProfile,-NonInteractive,-ExecutionPolicy,Bypass,-Command,\\\"" + scriptPath + "\\\"");
+        // Use -File for launching the wrapper to simplify the quoting
+        cmd.add("-args=-NoProfile,-NonInteractive,-ExecutionPolicy,Bypass,-File," + scriptPath);
+        cmd.add("-controldir=" + controlDirPath);
+        cmd.add("-result=" + resultFile);
+        cmd.add("-log=" + logFile);
+        if (capturingOutput) {
+            cmd.add("-output=" + outputFile);
+        }
+        if (LAUNCH_DIAGNOSTICS) {
+            cmd.add("-debug");
+        }
+        return cmd;
+    }
+
+    private List<String> scriptLauncherCmd(PowershellController c, FilePath ws, List<String> powershellArgs) throws IOException, InterruptedException {
+        List<String> args = new ArrayList<>();
+        String cmd;
+        if (capturingOutput) {
+            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -OutputFile '%s' -LogFile '%s' -ResultFile '%s' -CaptureOutput;",
+                    quote(c.getPowerShellHelperFile(ws)),
+                    quote(c.getPowerShellScriptFile(ws)),
+                    quote(c.getOutputFile(ws)),
+                    quote(c.getLogFile(ws)),
+                    quote(c.getResultFile(ws)));
+        } else {
+            cmd = String.format(". '%s'; Execute-AndWriteOutput -MainScript '%s' -LogFile '%s' -ResultFile '%s';",
+                    quote(c.getPowerShellHelperFile(ws)),
+                    quote(c.getPowerShellWrapperFile(ws)),
+                    quote(c.getLogFile(ws)),
+                    quote(c.getResultFile(ws)));
+        }
+
+        args.add(powershellBinary);
+        args.addAll(powershellArgs);
+        args.addAll(Arrays.asList("-Command", cmd));
+
+        return args;
     }
 
     private static String quote(FilePath f) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -103,7 +103,6 @@ public final class PowershellScript extends FileMonitoringTask {
         capturingOutput = true;
     }
 
-    @SuppressFBWarnings(value="VA_FORMAT_STRING_USES_NEWLINE", justification="%n from master might be \\n")
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
 
         FilePath nodeRoot = getNodeRoot(ws);
@@ -246,6 +245,7 @@ public final class PowershellScript extends FileMonitoringTask {
      * whoami -f || $($global:LASTEXITCODE = 0)
      *
      */
+    @SuppressFBWarnings(value="VA_FORMAT_STRING_USES_NEWLINE", justification=" from master might be \\n")
     private static String generateScriptWrapper(String powershellBinary, List<String> powershellArgs, FilePath powerShellScriptFile) {
         return String.format(
                 "[CmdletBinding()]\r\n" +

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -269,9 +269,9 @@ public final class PowershellScript extends FileMonitoringTask {
      */
     private static String generateScriptWrapper(String powershellBinary, List<String> powershellArgs, FilePath powerShellScriptFile) {
         return String.format(
-                "[CmdletBinding()]\r\n" +
-                "param()\r\n" +
-                "& %s %s -Command '& {try {& ''%s''} catch {throw}; exit $LASTEXITCODE}'\r\n" +
+                "[CmdletBinding()]\r%n" +
+                "param()\r%n" +
+                "& %s %s -Command '& {try {& ''%s''} catch {throw}; exit $LASTEXITCODE}'\r%n" +
                 "exit $LASTEXITCODE",
                 powershellBinary, String.join(" ", powershellArgs), quote(quote(powerShellScriptFile)));
     }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -55,7 +55,7 @@ import jenkins.model.Jenkins;
 public final class WindowsBatchScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_SHELL_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".FORCE_SHELL_WRAPPER");
+    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".FORCE_BINARY_WRAPPER");
 
     private final String script;
     private boolean capturingOutput;
@@ -91,7 +91,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         // launcher -daemon=true -shell=powershell -script=test.ps1 -log=logging.txt -result=result.txt -controldir=. -output=output.txt -debug
         List<String> launcherCmd = null;
-        if (!FORCE_SHELL_WRAPPER && agentInfo.isBinaryCompatible()) {
+        if (FORCE_BINARY_WRAPPER && agentInfo.isBinaryCompatible()) {
             FilePath controlDir = c.controlDir(ws);
             FilePath binary;
             if (agentInfo.isCachingAvailable()) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -89,7 +89,6 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         AgentInfo agentInfo = nodeRoot.act(new AgentInfo.GetAgentInfo(pluginVersion));
         BatchController c = new BatchController(ws);
 
-        // launcher -daemon=true -shell=powershell -script=test.ps1 -log=logging.txt -result=result.txt -controldir=. -output=output.txt -debug
         List<String> launcherCmd = null;
         if (FORCE_BINARY_WRAPPER && agentInfo.isBinaryCompatible()) {
             FilePath controlDir = c.controlDir(ws);
@@ -114,8 +113,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
             launcherCmd = scriptLauncherCmd(c, ws);
         }
 
-//        LOGGER.log(Level.FINE, "launching {0}", launcherCmd);
-        LOGGER.log(Level.INFO, "launching {0}", launcherCmd);
+        LOGGER.log(Level.FINE, "launching {0}", launcherCmd);
         Launcher.ProcStarter ps = launcher.launch().cmds(launcherCmd).envs(escape(envVars)).pwd(ws).quiet(true);
 
         /* Too noisy, and consumes a thread:

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -29,11 +29,9 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.PluginWrapper;
 import hudson.Proc;
 import hudson.model.TaskListener;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,12 +40,10 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import hudson.util.LineEndingConversion;
-import jenkins.model.Jenkins;
 
 /**
  * Runs a Windows batch script.
@@ -55,7 +51,7 @@ import jenkins.model.Jenkins;
 public final class WindowsBatchScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+    public static boolean USE_BINARY_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".FORCE_BINARY_WRAPPER");
 
     private final String script;
     private boolean capturingOutput;
@@ -91,7 +87,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         List<String> launcherCmd = null;
         FilePath binary;
-        if (FORCE_BINARY_WRAPPER && (binary = requestBinary(ws, c)) != null) {
+        if (USE_BINARY_WRAPPER && (binary = requestBinary(ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, binary.getRemote(), c.getBatchFile2(ws).getRemote());
             c.getBatchFile2(ws).write(script, "UTF-8");
         }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -51,7 +51,7 @@ import hudson.util.LineEndingConversion;
 public final class WindowsBatchScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean USE_BINARY_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+    public static boolean USE_BINARY_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".USE_BINARY_WRAPPER");
 
     private final String script;
     private boolean capturingOutput;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -142,13 +142,13 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         String cmdString;
         if (capturingOutput) {
-            cmdString = String.format("@echo off \r%ncmd /c call \"%s\" > \"%s\" 2> \"%s\"\r%necho %%ERRORLEVEL%% > \"%s\"\r%n",
+            cmdString = String.format("@echo off \r\ncmd /c call \"%s\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getOutputFile(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));
         } else {
-            cmdString = String.format("@echo off \r%ncmd /c call \"%s\" > \"%s\" 2>&1\r%necho %%ERRORLEVEL%% > \"%s\"\r%n",
+            cmdString = String.format("@echo off \r\ncmd /c call \"%s\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -55,7 +55,7 @@ import jenkins.model.Jenkins;
 public final class WindowsBatchScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean USE_SCRIPT_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".USE_SCRIPT_WRAPPER");
+    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".FORCE_BINARY_WRAPPER");
 
     private final String script;
     private boolean capturingOutput;
@@ -91,7 +91,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         List<String> launcherCmd = null;
         FilePath binary;
-        if (!USE_SCRIPT_WRAPPER && (binary = requestBinary(ws, c)) != null) {
+        if (FORCE_BINARY_WRAPPER && (binary = requestBinary(ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, binary.getRemote(), c.getBatchFile2(ws).getRemote());
             c.getBatchFile2(ws).write(script, "UTF-8");
         }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -55,7 +55,7 @@ import jenkins.model.Jenkins;
 public final class WindowsBatchScript extends FileMonitoringTask {
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL") // Used to control usage of binary or shell wrapper
     @Restricted(NoExternalUse.class)
-    public static boolean FORCE_BINARY_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".FORCE_BINARY_WRAPPER");
+    public static boolean USE_SCRIPT_WRAPPER = Boolean.getBoolean(WindowsBatchScript.class.getName() + ".USE_SCRIPT_WRAPPER");
 
     private final String script;
     private boolean capturingOutput;
@@ -91,7 +91,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         List<String> launcherCmd = null;
         FilePath binary;
-        if (FORCE_BINARY_WRAPPER && (binary = requestBinary(ws, c)) != null) {
+        if (!USE_SCRIPT_WRAPPER && (binary = requestBinary(ws, c)) != null) {
             launcherCmd = binaryLauncherCmd(c, ws, binary.getRemote(), c.getBatchFile2(ws).getRemote());
             c.getBatchFile2(ws).write(script, "UTF-8");
         }

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -163,13 +163,13 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
         String cmdString;
         if (capturingOutput) {
-            cmdString = String.format("@echo off \r\ncmd /c call \"%s\" > \"%s\" 2> \"%s\"\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
+            cmdString = String.format("@echo off \r%ncmd /c call \"%s\" > \"%s\" 2> \"%s\"\r%necho %%ERRORLEVEL%% > \"%s\"\r%n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getOutputFile(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));
         } else {
-            cmdString = String.format("@echo off \r\ncmd /c call \"%s\" > \"%s\" 2>&1\r\necho %%ERRORLEVEL%% > \"%s\"\r\n",
+            cmdString = String.format("@echo off \r%ncmd /c call \"%s\" > \"%s\" 2>&1\r%necho %%ERRORLEVEL%% > \"%s\"\r%n",
                 quote(c.getBatchFile2(ws)),
                 quote(c.getLogFile(ws)),
                 quote(c.getResultFile(ws)));

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -60,6 +60,14 @@ public final class WindowsBatchScript extends FileMonitoringTask {
     private final String script;
     private boolean capturingOutput;
     private static final Logger LOGGER = Logger.getLogger(WindowsBatchScript.class.getName());
+    private static final String LAUNCH_DIAGNOSTICS_PROP = WindowsBatchScript.class.getName() + ".LAUNCH_DIAGNOSTICS";
+
+    /**
+     * Used by the binary wrapper, this enables the debug flag.
+     */
+    @SuppressWarnings("FieldMayBeFinal")
+    // TODO use SystemProperties if and when unrestricted
+    private static boolean LAUNCH_DIAGNOSTICS = Boolean.getBoolean(LAUNCH_DIAGNOSTICS_PROP);
 
     @DataBoundConstructor public WindowsBatchScript(String script) {
         this.script = LineEndingConversion.convertEOL(script, LineEndingConversion.EOLType.Windows);
@@ -144,8 +152,9 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         if (capturingOutput) {
             cmd.add("-output=" + outputFile);
         }
-        // TODO: REMOVE
-        cmd.add("-debug");
+        if (LAUNCH_DIAGNOSTICS) {
+            cmd.add("-debug");
+        }
         return cmd;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -77,7 +77,6 @@ public final class WindowsBatchScript extends FileMonitoringTask {
         capturingOutput = true;
     }
 
-    @SuppressFBWarnings(value="VA_FORMAT_STRING_USES_NEWLINE", justification="%n from master might be \\n")
     @Override protected FileMonitoringController doLaunch(FilePath ws, Launcher launcher, TaskListener listener, EnvVars envVars) throws IOException, InterruptedException {
         if (launcher.isUnix()) {
             throw new IOException("Batch scripts can only be run on Windows nodes");
@@ -134,6 +133,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
     }
 
     @Nonnull
+    @SuppressFBWarnings(value="VA_FORMAT_STRING_USES_NEWLINE", justification="%n from master might be \\n")
     private List<String> scriptLauncherCmd(BatchController c, FilePath ws) throws IOException, InterruptedException {
 
         String cmdString;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -129,15 +129,16 @@ public class BourneShellScriptTest {
     @Before public void prepareAgentForPlatform() throws Exception {
         switch (platform) {
             case NATIVE:
+                BourneShellScript.FORCE_BINARY_WRAPPER = true;
                 s = j.createOnlineSlave();
                 break;
-            case UBUNTU_NO_BINARY:
-                BourneShellScript.USE_SCRIPT_WRAPPER = true;
             case SLIM:
             case ALPINE:
             case CENTOS:
             case UBUNTU:
             case NO_INIT:
+                BourneShellScript.FORCE_BINARY_WRAPPER = true;
+            case UBUNTU_NO_BINARY:
                 assumeDocker();
                 s = prepareAgentDocker();
                 j.jenkins.addNode(s);
@@ -198,7 +199,7 @@ public class BourneShellScriptTest {
         if (s != null) {
             j.jenkins.removeNode(s);
         }
-        BourneShellScript.USE_SCRIPT_WRAPPER = false;
+        BourneShellScript.FORCE_BINARY_WRAPPER = false;
     }
 
     @Test public void smokeTest() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -129,7 +129,7 @@ public class BourneShellScriptTest {
     @Before public void prepareAgentForPlatform() throws Exception {
         switch (platform) {
             case NATIVE:
-                BourneShellScript.FORCE_BINARY_WRAPPER = true;
+                BourneShellScript.USE_BINARY_WRAPPER = true;
                 s = j.createOnlineSlave();
                 break;
             case SLIM:
@@ -137,7 +137,7 @@ public class BourneShellScriptTest {
             case CENTOS:
             case UBUNTU:
             case NO_INIT:
-                BourneShellScript.FORCE_BINARY_WRAPPER = true;
+                BourneShellScript.USE_BINARY_WRAPPER = true;
             case UBUNTU_NO_BINARY:
                 assumeDocker();
                 s = prepareAgentDocker();
@@ -199,7 +199,7 @@ public class BourneShellScriptTest {
         if (s != null) {
             j.jenkins.removeNode(s);
         }
-        BourneShellScript.FORCE_BINARY_WRAPPER = false;
+        BourneShellScript.USE_BINARY_WRAPPER = false;
     }
 
     @Test public void smokeTest() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -129,16 +129,15 @@ public class BourneShellScriptTest {
     @Before public void prepareAgentForPlatform() throws Exception {
         switch (platform) {
             case NATIVE:
-                BourneShellScript.FORCE_BINARY_WRAPPER = true;
                 s = j.createOnlineSlave();
                 break;
+            case UBUNTU_NO_BINARY:
+                BourneShellScript.USE_SCRIPT_WRAPPER = true;
             case SLIM:
             case ALPINE:
             case CENTOS:
             case UBUNTU:
             case NO_INIT:
-                BourneShellScript.FORCE_BINARY_WRAPPER = true;
-            case UBUNTU_NO_BINARY:
                 assumeDocker();
                 s = prepareAgentDocker();
                 j.jenkins.addNode(s);
@@ -199,7 +198,7 @@ public class BourneShellScriptTest {
         if (s != null) {
             j.jenkins.removeNode(s);
         }
-        BourneShellScript.FORCE_BINARY_WRAPPER = false;
+        BourneShellScript.USE_SCRIPT_WRAPPER = false;
     }
 
     @Test public void smokeTest() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -482,8 +482,10 @@ public class BourneShellScriptTest {
                     String macArch = System.getProperty("os.arch");
                     if (macArch.contains("aarch") || macArch.contains("arm")) {
                         architecture = "arm";
-                    } else {
+                    } else if (macArch.contains("amd") || macArch.contains("x86")) {
                         architecture = "amd";
+                    } else {
+                        architecture = "NOTSUPPORTED";
                     }
                 } else {
                     os = "linux";

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -34,7 +34,6 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.DumbSlave;
-import hudson.slaves.OfflineCause;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -80,6 +79,7 @@ public class EncodingTest {
         assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
     }
     @Before public void setUp() throws Exception {
+        BourneShellScript.FORCE_BINARY_WRAPPER = true;
         s = null;
         BourneShellScriptTest.unix();
         BourneShellScriptTest.assumeDocker();
@@ -103,10 +103,9 @@ public class EncodingTest {
         }
     }
 
-    @AfterClass public static
-     void tearDown() throws Exception {
+    @After public void tearDown() throws Exception {
         if (s != null) {
-            s.toComputer().disconnect(new OfflineCause.UserCause(null, null));
+            r.jenkins.removeNode(s);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -79,7 +79,7 @@ public class EncodingTest {
         assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
     }
     @Before public void setUp() throws Exception {
-        BourneShellScript.FORCE_BINARY_WRAPPER = true;
+        BourneShellScript.USE_BINARY_WRAPPER = true;
         s = null;
         BourneShellScriptTest.unix();
         BourneShellScriptTest.assumeDocker();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -37,6 +37,7 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -49,14 +50,13 @@ import java.util.logging.Level;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.output.TeeOutputStream;
 import static org.hamcrest.Matchers.containsString;
-import org.jenkinsci.test.acceptance.docker.DockerClassRule;
+import org.jenkinsci.test.acceptance.docker.DockerRule;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
-import org.junit.AfterClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
+
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
-import org.junit.BeforeClass;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
@@ -67,22 +67,25 @@ import org.jvnet.hudson.test.LoggerRule;
 @RunWith(Parameterized.class)
 public class EncodingTest {
 
-    @ClassRule public static LoggerRule logging = new LoggerRule().recordPackage(BourneShellScript.class, Level.FINE);
-    @ClassRule public static JenkinsRule r = new JenkinsRule();
-    @ClassRule public static DockerClassRule<JavaContainer> dockerUbuntu = new DockerClassRule<>(JavaContainer.class);
+    @Rule public LoggerRule logging = new LoggerRule().recordPackage(EncodingTest.class, Level.FINE);
+    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public DockerRule<JavaContainer> dockerUbuntu = new DockerRule<>(JavaContainer.class);
 
     private static DumbSlave s;
     private static StreamTaskListener listener;
     private static FilePath ws;
     private static Launcher launcher;
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass public static void unix() throws Exception {
+        assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
+    }
+    @Before public void setUp() throws Exception {
         s = null;
         BourneShellScriptTest.unix();
         BourneShellScriptTest.assumeDocker();
         listener = StreamTaskListener.fromStdout();
         launcher = r.jenkins.createLauncher(listener);
-        JavaContainer container = dockerUbuntu.create();
+        JavaContainer container = dockerUbuntu.get();
         SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(Domain.global(), Collections.<Credentials>singletonList(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "test", "test"))));
         SSHLauncher sshLauncher = new SSHLauncher(container.ipBound(22), container.port(22), "test");
         sshLauncher.setJvmOptions("-Dfile.encoding=ISO-8859-1");

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -79,6 +79,7 @@ public class EncodingTest {
         assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
     }
     @Before public void setUp() throws Exception {
+        BourneShellScript.FORCE_BINARY_WRAPPER = true;
         s = null;
         BourneShellScriptTest.unix();
         BourneShellScriptTest.assumeDocker();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/EncodingTest.java
@@ -79,7 +79,6 @@ public class EncodingTest {
         assumeTrue("This test is only for Unix", File.pathSeparatorChar==':');
     }
     @Before public void setUp() throws Exception {
-        BourneShellScript.FORCE_BINARY_WRAPPER = true;
         s = null;
         BourneShellScriptTest.unix();
         BourneShellScriptTest.assumeDocker();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
@@ -79,7 +79,6 @@ public class PowerShellCoreScriptTest {
 
     @Before
     public void setUp() throws Exception {
-        PowershellScript.FORCE_BINARY_WRAPPER = true;
         listener = StreamTaskListener.fromStdout();
         if (pwshExists) {
             s = j.createOnlineSlave();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowerShellCoreScriptTest.java
@@ -79,6 +79,7 @@ public class PowerShellCoreScriptTest {
 
     @Before
     public void setUp() throws Exception {
+        PowershellScript.FORCE_BINARY_WRAPPER = true;
         listener = StreamTaskListener.fromStdout();
         if (pwshExists) {
             s = j.createOnlineSlave();

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -295,7 +295,6 @@ public class PowershellScriptTest {
         c.writeLog(ws, baos);
         assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher, TaskListener.NULL));
         String log = baos.toString("UTF-8");
-        assertTrue(log, log.contains("Helló, Wõrld ®"));
         if (launcher.isUnix()) {
             assertEquals("Helló, Wõrld ®\n", new String(c.getOutput(ws, launcher)));
         } else {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -73,7 +73,7 @@ public class PowershellScriptTest {
     }
 
     @Before public void vars() throws IOException, InterruptedException {
-        PowershellScript.FORCE_BINARY_WRAPPER = enableBinary;
+        PowershellScript.USE_BINARY_WRAPPER = enableBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -367,6 +367,6 @@ public class PowershellScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(1500); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(3000); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -367,6 +367,6 @@ public class PowershellScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(3000); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(500); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -66,14 +66,14 @@ public class PowershellScriptTest {
     private Launcher launcher;
     private int psVersion;
     private boolean enablePwsh = false;
-    private boolean enableBinary;
+    private boolean useBinary;
 
-    public PowershellScriptTest(boolean enableBinary) {
-        this.enableBinary = enableBinary;
+    public PowershellScriptTest(boolean useBinary) {
+        this.useBinary = useBinary;
     }
 
-    @Before public void vars() throws IOException, InterruptedException {
-        PowershellScript.FORCE_BINARY_WRAPPER = enableBinary;
+    @Before public void vars() throws IOException {
+        PowershellScript.USE_SCRIPT_WRAPPER = !useBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -43,13 +43,22 @@ import static org.junit.Assert.*;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 import org.jvnet.hudson.test.JenkinsRule;
 import java.util.Properties;
 import java.util.*;
 import org.apache.commons.io.IOUtils;
 import org.junit.AssumptionViolatedException;
 
+@RunWith(Parameterized.class)
 public class PowershellScriptTest {
+    @Parameters(name = "{index}: USE_BINARY={0}")
+    public static Object[] parameters() {
+        return new Object[] {true, false};
+    }
+
     @Rule public JenkinsRule j = new JenkinsRule();
 
     private StreamTaskListener listener;
@@ -57,9 +66,14 @@ public class PowershellScriptTest {
     private Launcher launcher;
     private int psVersion;
     private boolean enablePwsh = false;
+    private boolean enableBinary;
+
+    public PowershellScriptTest(boolean enableBinary) {
+        this.enableBinary = enableBinary;
+    }
 
     @Before public void vars() throws IOException, InterruptedException {
-        PowershellScript.FORCE_BINARY_WRAPPER = true;
+        PowershellScript.FORCE_BINARY_WRAPPER = enableBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -367,6 +367,6 @@ public class PowershellScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(500); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(1000); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -367,6 +367,6 @@ public class PowershellScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(1000); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(1500); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -66,14 +66,14 @@ public class PowershellScriptTest {
     private Launcher launcher;
     private int psVersion;
     private boolean enablePwsh = false;
-    private boolean useBinary;
+    private boolean enableBinary;
 
-    public PowershellScriptTest(boolean useBinary) {
-        this.useBinary = useBinary;
+    public PowershellScriptTest(boolean enableBinary) {
+        this.enableBinary = enableBinary;
     }
 
-    @Before public void vars() throws IOException {
-        PowershellScript.USE_SCRIPT_WRAPPER = !useBinary;
+    @Before public void vars() throws IOException, InterruptedException {
+        PowershellScript.FORCE_BINARY_WRAPPER = enableBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -29,7 +29,6 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Proc;
 import hudson.model.TaskListener;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,11 +36,11 @@ import java.io.IOException;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import static org.hamcrest.Matchers.containsString;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -50,7 +49,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.util.Properties;
 import java.util.*;
 import org.apache.commons.io.IOUtils;
-import org.junit.AssumptionViolatedException;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.containsString;
 
 @RunWith(Parameterized.class)
 public class PowershellScriptTest {
@@ -60,6 +61,13 @@ public class PowershellScriptTest {
     }
 
     @Rule public JenkinsRule j = new JenkinsRule();
+
+    @BeforeClass
+    public static void setup() {
+        // increase delete attempts as it takes the binary a little longer to release resources
+        System.setProperty("hudson.Util.maxFileDeletionRetries", "6");
+        System.setProperty("hudson.Util.deletionRetryWait", "500");
+    }
 
     private StreamTaskListener listener;
     private FilePath ws;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -327,7 +327,7 @@ public class PowershellScriptTest {
 
     @Test public void correctExitCode() throws Exception {
         PowershellScript s = new PowershellScript("exit 5;");
-        s.setPowershellBinary("pwsh");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
         Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         assertEquals(Integer.valueOf(5), c.exitStatus(ws, launcher, TaskListener.NULL));

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -56,11 +56,10 @@ public class PowershellScriptTest {
     private FilePath ws;
     private Launcher launcher;
     private int psVersion;
+    private boolean enablePwsh = false;
 
     @Before public void vars() throws IOException, InterruptedException {
         PowershellScript.FORCE_BINARY_WRAPPER = true;
-        // TODO: REMOVE
-        System.setProperty(PowershellScript.class.getName() + ".LAUNCH_DIAGNOSTICS", "true");
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);
@@ -102,7 +101,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void explicitExit() throws Exception {
-        Controller c = new PowershellScript("Write-Output \"Hello, World!\"; exit 1;").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Write-Output \"Hello, World!\"; exit 1;");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -112,7 +113,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void implicitExit() throws Exception {
-        Controller c = new PowershellScript("Write-Output \"Success!\";").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Write-Output \"Success!\";");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -122,7 +125,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void implicitError() throws Exception {
-        Controller c = new PowershellScript("$ErrorActionPreference = 'Stop'; Write-Error \"Bogus error\"").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("$ErrorActionPreference = 'Stop'; Write-Error \"Bogus error\"");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -132,14 +137,18 @@ public class PowershellScriptTest {
     }
 
     @Test public void implicitErrorNegativeTest() throws Exception {
-        Controller c = new PowershellScript("$ErrorActionPreference = 'SilentlyContinue'; Write-Error \"Bogus error\"").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("$ErrorActionPreference = 'SilentlyContinue'; Write-Error \"Bogus error\"");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         assertTrue(c.exitStatus(ws, launcher, TaskListener.NULL).intValue() == 0);
         c.cleanup(ws);
     }
 
     @Test public void parseError() throws Exception {
-        Controller c = new PowershellScript("Write-Output \"Hello, World!").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Write-Output \"Hello, World!");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -149,7 +158,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void invocationCommandNotExistError() throws Exception {
-        Controller c = new PowershellScript("Get-VerbDoesNotExist").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Get-VerbDoesNotExist");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -159,7 +170,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void invocationParameterNotExistError() throws Exception {
-        Controller c = new PowershellScript("Get-Date -PARAMDOESNOTEXIST").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Get-Date -PARAMDOESNOTEXIST");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -169,7 +182,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void invocationParameterBindingError() throws Exception {
-        Controller c = new PowershellScript("Get-Command -CommandType DOESNOTEXIST").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Get-Command -CommandType DOESNOTEXIST");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -179,7 +194,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void invocationParameterValidationError() throws Exception {
-        Controller c = new PowershellScript("Get-Date -Month 15").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Get-Date -Month 15");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -188,7 +205,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void cmdletBindingScriptDoesNotError() throws Exception {
-        Controller c = new PowershellScript("[CmdletBinding()]param([Parameter()][string]$Param1) \"Param1 = $Param1\"").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("[CmdletBinding()]param([Parameter()][string]$Param1) \"Param1 = $Param1\"");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -197,9 +216,10 @@ public class PowershellScriptTest {
     }
 
     @Test public void explicitThrow() throws Exception {
-        DurableTask task = new PowershellScript("Write-Output \"Hello, World!\"; throw \"explicit error\";");
-        task.captureOutput();
-        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Write-Output \"Hello, World!\"; throw \"explicit error\";");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        s.captureOutput();
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -214,8 +234,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void implicitThrow() throws Exception {
-        DurableTask task = new PowershellScript("$ErrorActionPreference = 'Stop'; My-BogusCmdlet;");
-        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("$ErrorActionPreference = 'Stop'; My-BogusCmdlet;");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -225,15 +246,16 @@ public class PowershellScriptTest {
     }
 
     @Test public void noStdoutPollution() throws Exception {
-        DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; " +
-                                                "$WarningPreference = \"Continue\"; " +
-                                                "$DebugPreference = \"Continue\"; " +
-                                                "Write-Verbose \"Hello, Verbose!\"; " +
-                                                "Write-Warning \"Hello, Warning!\"; " +
-                                                "Write-Debug \"Hello, Debug!\"; " +
-                                                "Write-Output \"Success\"");
-        task.captureOutput();
-        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("$VerbosePreference = \"Continue\"; " +
+                                                  "$WarningPreference = \"Continue\"; " +
+                                                  "$DebugPreference = \"Continue\"; " +
+                                                  "Write-Verbose \"Hello, Verbose!\"; " +
+                                                  "Write-Warning \"Hello, Warning!\"; " +
+                                                  "Write-Debug \"Hello, Debug!\"; " +
+                                                  "Write-Output \"Success\"");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        s.captureOutput();
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -250,13 +272,14 @@ public class PowershellScriptTest {
     }
 
     @Test public void specialStreams() throws Exception {
-        DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; " +
-                                                "$WarningPreference = \"Continue\"; " +
-                                                "$DebugPreference = \"Continue\"; " +
-                                                "Write-Verbose \"Hello, Verbose!\"; " +
-                                                "Write-Warning \"Hello, Warning!\"; " +
-                                                "Write-Debug \"Hello, Debug!\";");
-        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("$VerbosePreference = \"Continue\"; " +
+                                                  "$WarningPreference = \"Continue\"; " +
+                                                  "$DebugPreference = \"Continue\"; " +
+                                                  "Write-Verbose \"Hello, Verbose!\"; " +
+                                                  "Write-Warning \"Hello, Warning!\"; " +
+                                                  "Write-Debug \"Hello, Debug!\";");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -269,14 +292,18 @@ public class PowershellScriptTest {
 
     @Test public void spacesInWorkspace() throws Exception {
         final FilePath newWs = new FilePath(ws, "subdirectory with spaces");
-        Controller c = new PowershellScript("Write-Host 'Running in a workspace with spaces in the path'").launch(new EnvVars(), newWs, launcher, listener);
+        PowershellScript s = new PowershellScript("Write-Host 'Running in a workspace with spaces in the path'");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         assertEquals(0, c.exitStatus(newWs, launcher, TaskListener.NULL).intValue());
         c.cleanup(ws);
     }
 
     @Test public void echoEnvVar() throws Exception {
-        Controller c = new PowershellScript("echo envvar=$env:MYVAR").launch(new EnvVars("MYVAR", "power$hell"), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("echo envvar=$env:MYVAR");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars("MYVAR", "power$hell"), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws,baos);
@@ -286,7 +313,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void unicodeChars() throws Exception {
-        Controller c = new PowershellScript("Write-Output \"Helló, Wõrld ®\";").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("Write-Output \"Helló, Wõrld ®\";");
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
@@ -297,7 +326,9 @@ public class PowershellScriptTest {
     }
 
     @Test public void correctExitCode() throws Exception {
-        Controller c = new PowershellScript("exit 5;").launch(new EnvVars(), ws, launcher, listener);
+        PowershellScript s = new PowershellScript("exit 5;");
+        s.setPowershellBinary("pwsh");
+        Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         assertEquals(Integer.valueOf(5), c.exitStatus(ws, launcher, TaskListener.NULL));
         c.cleanup(ws);
@@ -305,7 +336,7 @@ public class PowershellScriptTest {
 
     @Test public void checkProfile() throws Exception {
         PowershellScript s = new PowershellScript("if ((Get-CimInstance Win32_Process -Filter \"ProcessId = $PID\").CommandLine.split(\" \").Contains(\"-NoProfile\")) { exit 0; } else { exit 1; } ");
-
+        if (enablePwsh) {s.setPowershellBinary("pwsh");}
         Controller c = s.launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -41,7 +41,7 @@ import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -60,7 +60,7 @@ public class PowershellScriptTest {
         return new Object[] {true, false};
     }
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @ClassRule public static JenkinsRule j = new JenkinsRule();
 
     @BeforeClass
     public static void setup() {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -225,8 +225,8 @@ public class PowershellScriptTest {
     }
 
     @Test public void noStdoutPollution() throws Exception {
-        // TODO temporary
-        System.setProperty(PowershellScript.class.getName() + ".LAUNCH_DIAGNOSTICS", "false");
+        // TODO? Binary wrapper does not allow redirection of non-success streams to the logger
+        PowershellScript.FORCE_BINARY_WRAPPER = false;
         DurableTask task = new PowershellScript("$VerbosePreference = \"Continue\"; " +
                                                 "$WarningPreference = \"Continue\"; " +
                                                 "$DebugPreference = \"Continue\"; " +
@@ -249,8 +249,7 @@ public class PowershellScriptTest {
             assertEquals("Success\r\n", new String(c.getOutput(ws, launcher)));
         }
         c.cleanup(ws);
-        // TODO temporary
-        System.setProperty(PowershellScript.class.getName() + ".LAUNCH_DIAGNOSTICS", "true");
+        PowershellScript.FORCE_BINARY_WRAPPER = true;
     }
 
     @Test public void specialStreams() throws Exception {
@@ -290,7 +289,6 @@ public class PowershellScriptTest {
     }
 
     @Test public void unicodeChars() throws Exception {
-//        PowershellScript.FORCE_BINARY_WRAPPER = false;
         Controller c = new PowershellScript("Write-Output \"Helló, Wõrld ®\";").launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -327,6 +325,6 @@ public class PowershellScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(5000); // Need pause or else cleanup is attempted before processes are completed
+        Thread.sleep(3000); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -40,11 +40,12 @@ import org.junit.Test;
 import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.jvnet.hudson.test.FlagRule;
 import org.jvnet.hudson.test.JenkinsRule;
 import java.util.Properties;
 import java.util.*;
@@ -60,14 +61,10 @@ public class PowershellScriptTest {
         return new Object[] {true, false};
     }
 
-    @ClassRule public static JenkinsRule j = new JenkinsRule();
-
-    @BeforeClass
-    public static void setup() {
-        // increase delete attempts as it takes the binary a little longer to release resources
-        System.setProperty("hudson.Util.maxFileDeletionRetries", "6");
-        System.setProperty("hudson.Util.deletionRetryWait", "500");
-    }
+    // increase delete attempts as it takes the binary a little longer to release resources
+    @ClassRule public static FlagRule retryRule = FlagRule.systemProperty("hudson.Util.maxFileDeletionRetries", "6");
+    @ClassRule public static FlagRule waitRule = FlagRule.systemProperty("hudson.Util.deletionRetryWait", "500");
+    @Rule public JenkinsRule j = new JenkinsRule();
 
     private StreamTaskListener listener;
     private FilePath ws;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/PowershellScriptTest.java
@@ -285,21 +285,14 @@ public class PowershellScriptTest {
         c.cleanup(ws);
     }
 
-    // Note: test will fail if capture output is enabled. Captured output is written in ascii
     @Test public void unicodeChars() throws Exception {
-        DurableTask task = new PowershellScript("Write-Output \"Helló, Wõrld ®\";");//.launch(new EnvVars(), ws, launcher, listener);
-        task.captureOutput();
-        Controller c = task.launch(new EnvVars(), ws, launcher, listener);
+        Controller c = new PowershellScript("Write-Output \"Helló, Wõrld ®\";").launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(Integer.valueOf(0), c.exitStatus(ws, launcher, TaskListener.NULL));
         String log = baos.toString("UTF-8");
-        if (launcher.isUnix()) {
-            assertEquals("Helló, Wõrld ®\n", new String(c.getOutput(ws, launcher)));
-        } else {
-            assertEquals("Helló, Wõrld ®\r\n", new String(c.getOutput(ws, launcher)));
-        }
+        assertTrue(log, log.contains("Helló, Wõrld ®"));
         c.cleanup(ws);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -169,7 +169,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(3000); // Need pause or else cleanup is attempted before processes are completed
+        Thread.sleep(3000); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -30,20 +30,20 @@ import hudson.Launcher;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import static org.hamcrest.Matchers.containsString;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
 import java.io.IOException;
 import java.util.Arrays;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class WindowsBatchScriptTest {
@@ -56,6 +56,9 @@ public class WindowsBatchScriptTest {
 
     @BeforeClass public static void windows() {
         Assume.assumeTrue("These tests are only for Windows", File.pathSeparatorChar == ';');
+        // increase delete attempts as it takes the binary a little longer to release resources
+        System.setProperty("hudson.Util.maxFileDeletionRetries", "6");
+        System.setProperty("hudson.Util.deletionRetryWait", "500");
     }
 
     private StreamTaskListener listener;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -34,9 +34,11 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.FlagRule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import java.io.IOException;
@@ -52,13 +54,13 @@ public class WindowsBatchScriptTest {
         return new Object[] {true, false};
     }
 
-    @ClassRule public static JenkinsRule j = new JenkinsRule();
+    // increase delete attempts as it takes the binary a little longer to release resources
+    @ClassRule public static FlagRule retryRule = FlagRule.systemProperty("hudson.Util.maxFileDeletionRetries", "6");
+    @ClassRule public static FlagRule waitRule = FlagRule.systemProperty("hudson.Util.deletionRetryWait", "500");
+    @Rule public JenkinsRule j = new JenkinsRule();
 
     @BeforeClass public static void windows() {
         Assume.assumeTrue("These tests are only for Windows", File.pathSeparatorChar == ';');
-        // increase delete attempts as it takes the binary a little longer to release resources
-        System.setProperty("hudson.Util.maxFileDeletionRetries", "6");
-        System.setProperty("hudson.Util.deletionRetryWait", "500");
     }
 
     private StreamTaskListener listener;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -68,7 +68,7 @@ public class WindowsBatchScriptTest {
     }
 
     @Before public void vars() {
-        WindowsBatchScript.FORCE_BINARY_WRAPPER = enableBinary;
+        WindowsBatchScript.USE_BINARY_WRAPPER = enableBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -191,7 +191,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(500); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(1000); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -30,7 +30,6 @@ import hudson.Launcher;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import org.apache.commons.io.output.TeeOutputStream;
 import static org.hamcrest.Matchers.containsString;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -174,6 +173,17 @@ public class WindowsBatchScriptTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(ws, baos);
         assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
+        c.cleanup(ws);
+    }
+
+    @Test public void unicodeChars() throws Exception {
+        Controller c = new WindowsBatchScript("echo Helló, Wõrld ®").launch(new EnvVars(), ws, launcher, listener);
+        awaitCompletion(c);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        assertEquals(0, c.exitStatus(ws, launcher, listener).intValue());
+        String log = baos.toString("UTF-8");
+        assertTrue(log, log.contains("Helló, Wõrld ®"));
         c.cleanup(ws);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -191,7 +191,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(1000); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(1500); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -169,7 +169,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(1000); // Need pause or else cleanup is attempted before processes are completed
+        Thread.sleep(3000); // Need pause or else cleanup is attempted before processes are completed
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -57,6 +57,7 @@ public class WindowsBatchScriptTest {
     private Launcher launcher;
 
     @Before public void vars() {
+        WindowsBatchScript.FORCE_BINARY_WRAPPER = true;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -191,7 +191,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(3000); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(500); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -61,14 +61,14 @@ public class WindowsBatchScriptTest {
     private StreamTaskListener listener;
     private FilePath ws;
     private Launcher launcher;
-    private boolean enableBinary;
+    private boolean useBinary;
 
-    public WindowsBatchScriptTest(boolean enableBinary) {
-        this.enableBinary = enableBinary;
+    public WindowsBatchScriptTest(boolean useBinary) {
+        this.useBinary = useBinary;
     }
 
     @Before public void vars() {
-        WindowsBatchScript.FORCE_BINARY_WRAPPER = enableBinary;
+        WindowsBatchScript.USE_SCRIPT_WRAPPER = !useBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -81,6 +81,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(wsWithPath, launcher, listener) == null) {
             Thread.sleep(100);
         }
+        Thread.sleep(3000); // Need pause or else cleanup will fail due to AccessDeniedException when deleting binary
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         c.writeLog(wsWithPath, baos);
         assertEquals(Integer.valueOf(0), c.exitStatus(wsWithPath, launcher, listener));

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -61,14 +61,14 @@ public class WindowsBatchScriptTest {
     private StreamTaskListener listener;
     private FilePath ws;
     private Launcher launcher;
-    private boolean useBinary;
+    private boolean enableBinary;
 
-    public WindowsBatchScriptTest(boolean useBinary) {
-        this.useBinary = useBinary;
+    public WindowsBatchScriptTest(boolean enableBinary) {
+        this.enableBinary = enableBinary;
     }
 
     @Before public void vars() {
-        WindowsBatchScript.USE_SCRIPT_WRAPPER = !useBinary;
+        WindowsBatchScript.FORCE_BINARY_WRAPPER = enableBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -169,7 +169,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(1000); // Need pause or else cleanup is attempted before resources are released
+        Thread.sleep(1000); // Need pause or else cleanup is attempted before processes are completed
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -33,7 +33,7 @@ import java.io.File;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -52,7 +52,7 @@ public class WindowsBatchScriptTest {
         return new Object[] {true, false};
     }
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @ClassRule public static JenkinsRule j = new JenkinsRule();
 
     @BeforeClass public static void windows() {
         Assume.assumeTrue("These tests are only for Windows", File.pathSeparatorChar == ';');

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -38,13 +38,20 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 import java.util.Arrays;
 
+@RunWith(Parameterized.class)
 public class WindowsBatchScriptTest {
+    @Parameterized.Parameters(name = "{index}: USE_BINARY={0}")
+    public static Object[] parameters() {
+        return new Object[] {true, false};
+    }
 
     @Rule public JenkinsRule j = new JenkinsRule();
 
@@ -55,9 +62,14 @@ public class WindowsBatchScriptTest {
     private StreamTaskListener listener;
     private FilePath ws;
     private Launcher launcher;
+    private boolean enableBinary;
+
+    public WindowsBatchScriptTest(boolean enableBinary) {
+        this.enableBinary = enableBinary;
+    }
 
     @Before public void vars() {
-        WindowsBatchScript.FORCE_BINARY_WRAPPER = true;
+        WindowsBatchScript.FORCE_BINARY_WRAPPER = enableBinary;
         listener = StreamTaskListener.fromStdout();
         ws = j.jenkins.getRootPath().child("ws");
         launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -191,7 +191,7 @@ public class WindowsBatchScriptTest {
         while (c.exitStatus(ws, launcher, listener) == null) {
             Thread.sleep(100);
         }
-        Thread.sleep(1500); // Pause allows slower systems to exit binary before cleanup is attempted
+        Thread.sleep(3000); // Pause allows slower systems to exit binary before cleanup is attempted
     }
 
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Adding support for windows binary to launch powershell and batch scripts in a new process group.
Downstream of https://github.com/jenkinsci/lib-durable-task/pull/7

The following system properties must be added to the `jenkins.xml` file in the windows installation path
`-Dorg.jenkinsci.plugins.durabletask.WindowsBatchScript.FORCE_BINARY_WRAPPER=true`
`-Dorg.jenkinsci.plugins.durabletask.PowershellScript.FORCE_BINARY_WRAPPER=true`


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
