### PR TITLE
bump jenkins core to 2.277.1, parent pom, and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.19</version>
         <relativePath />
     </parent>
     <artifactId>durable-task</artifactId>
@@ -22,8 +22,9 @@
     <properties>
         <revision>1.38</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.150.1</jenkins.version>
+        <jenkins.version>2.249.3</jenkins.version>
         <java.level>8</java.level>
+        <!--        <slf4j.version>1.7.26</slf4j.version>-->
     </properties>
 
     <repositories>
@@ -54,22 +55,27 @@
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>
             <artifactId>docker-fixtures</artifactId>
-            <version>1.8</version>
+            <version>1.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.30.0</version>
+            <version>1.31.5</version> <!-- TODO: Remove version when core is 2.277 or greater (included in BOM) -->
             <scope>test</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.249.x</artifactId>
+                <version>876.vc43b4c6423b6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>
-                <version>1.17</version>
+                <version>1.20</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
+                <artifactId>bom-2.277.x</artifactId>
                 <version>887.vae9c8ac09ff7</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,8 @@
     <properties>
         <revision>1.38</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.249.3</jenkins.version>
+        <jenkins.version>2.277.1</jenkins.version>
         <java.level>8</java.level>
-        <!--        <slf4j.version>1.7.26</slf4j.version>-->
     </properties>
 
     <repositories>
@@ -61,7 +60,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.31.5</version> <!-- TODO: Remove version when core is 2.277 or greater (included in BOM) -->
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -70,12 +68,9 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.249.x</artifactId>
-                <version>876.vc43b4c6423b6</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>symbol-annotation</artifactId>
-                <version>1.20</version>
+                <version>887.vae9c8ac09ff7</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Bumping jenkins core to 2.277.1. The current version (2.150) cannot even load pipelines.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
