### PR TITLE
Switch from MD5 to SHA-256 algorithm to hash JENKINS_SERVER_COOKIE value

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -155,6 +155,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         // The temporary variable is to ensure JENKINS_SERVER_COOKIE=durable-… does not appear even in argv[], lest it be confused with the environment.
         envVars.put(cookieVariable, "please-do-not-kill-me");
+        envVars.put(FileMonitoringTask.COOKIE_OLD, "please-do-not-kill-me"); // To maintain backward compatibility
 
         List<String> launcherCmd = null;
         FilePath binary;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -155,7 +155,6 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         // The temporary variable is to ensure JENKINS_SERVER_COOKIE=durable-… does not appear even in argv[], lest it be confused with the environment.
         envVars.put(cookieVariable, "please-do-not-kill-me");
-        envVars.put(FileMonitoringTask.COOKIE_OLD, "please-do-not-kill-me"); // To maintain backward compatibility
 
         List<String> launcherCmd = null;
         FilePath binary;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.durabletask;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -135,7 +136,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             scriptEncodingCharset = zOSSystemEncodingCharset.name();
         }
 
-        ShellController c = new ShellController(ws,(os == OsType.ZOS));
+        ShellController c = new ShellController(ws,(os == OsType.ZOS), cookieValue);
         FilePath shf = c.getScriptFile(ws);
 
         shf.write(script, scriptEncodingCharset);
@@ -275,8 +276,8 @@ public final class BourneShellScript extends FileMonitoringTask {
         /** Caching zOS flag to avoid round trip calls in exitStatus()         */
         private final boolean isZos;
 
-        private ShellController(FilePath ws, boolean zOsFlag) throws IOException, InterruptedException {
-            super(ws, cookieFor(ws));
+        private ShellController(FilePath ws, boolean zOsFlag, @NonNull String cookieValue) throws IOException, InterruptedException {
+            super(ws, cookieValue);
             this.isZos = zOsFlag;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -276,7 +276,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         private final boolean isZos;
 
         private ShellController(FilePath ws, boolean zOsFlag) throws IOException, InterruptedException {
-            super(ws);
+            super(ws, cookieFor(ws));
             this.isZos = zOsFlag;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -61,6 +61,8 @@ import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -104,7 +106,15 @@ public abstract class FileMonitoringTask extends DurableTask {
     private @CheckForNull String charset;
 
     private static String cookieFor(FilePath workspace) {
-        return "durable-" + Util.getDigestOf(workspace.getRemote());
+        return "durable-" + digest(workspace.getRemote());
+    }
+
+    private static String digest(String text) {
+        try {
+            return Util.toHexString(MessageDigest.getInstance("SHA-256").digest(text.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new Error(e);
+        }
     }
 
     @Override public final Controller launch(EnvVars env, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -64,7 +64,6 @@ import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -470,10 +469,8 @@ public abstract class FileMonitoringTask extends DurableTask {
         }
 
         @Override public final void stop(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
-            Map<String, String> cookiesMap = new HashMap<>();
-            cookiesMap.put(COOKIE, cookieFor(workspace));
-            cookiesMap.put(COOKIE_OLD, cookieFor(workspace, true)); // To maintain backward compatibility 
-            launcher.kill(Collections.unmodifiableMap(cookiesMap));
+            launcher.kill(Collections.singletonMap(COOKIE, cookieFor(workspace)));
+            launcher.kill(Collections.singletonMap(COOKIE_OLD, cookieFor(workspace, true))); // To maintain backward compatibility
         }
 
         @Override public void cleanup(FilePath workspace) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -115,8 +115,7 @@ public abstract class FileMonitoringTask extends DurableTask {
      * @return the cookie value
      */
     private static String cookieFor(FilePath workspace, boolean old) {
-        String remote = workspace.getRemote();
-        return String.format("durable-%s", old ? Util.getDigestOf(remote) : digest(remote));
+        return String.format("durable-%s", old ? Util.getDigestOf(workspace.getRemote()) : digest(workspace.getRemote()));
     }
     
     private static String cookieFor(FilePath workspace) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -93,10 +93,7 @@ public abstract class FileMonitoringTask extends DurableTask {
 
     private static final Logger LOGGER = Logger.getLogger(FileMonitoringTask.class.getName());
 
-    private static final String COOKIE = "JENKINS_SERVER_COOKIE_ID";
-    
-    /** To maintain backward compatibility */
-    private static final String COOKIE_OLD = "JENKINS_SERVER_COOKIE";
+    private static final String COOKIE = "JENKINS_SERVER_COOKIE";
     
     protected static final String BINARY_RESOURCE_PREFIX = "/io/jenkins/plugins/lib-durable-task/durable_task_monitor_";
 
@@ -470,7 +467,7 @@ public abstract class FileMonitoringTask extends DurableTask {
 
         @Override public final void stop(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
             launcher.kill(Collections.singletonMap(COOKIE, cookieFor(workspace)));
-            launcher.kill(Collections.singletonMap(COOKIE_OLD, cookieFor(workspace, true))); // To maintain backward compatibility
+            launcher.kill(Collections.singletonMap(COOKIE, cookieFor(workspace, true))); // To maintain backward compatibility
         }
 
         @Override public void cleanup(FilePath workspace) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -113,8 +113,8 @@ public abstract class FileMonitoringTask extends DurableTask {
      * a flag to identify if we want this cookie hash based on MD5 (former/old format) or SHA-256 algorithm.
      * This method is only used to maintain backward compatibility on stopping tasks that were
      * launched before the new format was applied.
-     * @param workspace
-     * @param old
+     * @param workspace - workspace path used to setup the digest
+     * @param old - boolean to select if we want to use former/old hash algorithm to maintain backward compatibility
      * @return
      */
     private static String cookieFor(FilePath workspace, boolean old) {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -95,7 +95,7 @@ public abstract class FileMonitoringTask extends DurableTask {
 
     private static final Logger LOGGER = Logger.getLogger(FileMonitoringTask.class.getName());
 
-    private static final String COOKIE = "JENKINS_SERVER_COOKIE";
+    protected static final String COOKIE = "JENKINS_SERVER_COOKIE";
 
     protected static final String BINARY_RESOURCE_PREFIX = "/io/jenkins/plugins/lib-durable-task/durable_task_monitor_";
 
@@ -112,15 +112,15 @@ public abstract class FileMonitoringTask extends DurableTask {
      * a flag to identify if we want this cookie hash based on MD5 (former/old format) or SHA-256 algorithm.
      * This method is only used to maintain backward compatibility on stopping tasks that were
      * launched before the new format was applied.
-     * @param workspace - workspace path used to setup the digest
-     * @param old - boolean to select if we want to use former/old hash algorithm to maintain backward compatibility
+     * @param workspace path used to setup the digest
+     * @param boolean to select if we want to use former/old hash algorithm to maintain backward compatibility
      * @return the cookie value
      */
     private static String cookieFor(FilePath workspace, boolean old) {
         return String.format("durable-%s", old ? Util.getDigestOf(workspace.getRemote()) : digest(workspace.getRemote()));
     }
     
-    public static String cookieFor(FilePath workspace) {
+    private static String cookieFor(FilePath workspace) {
         return cookieFor(workspace, false);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -94,7 +94,7 @@ public abstract class FileMonitoringTask extends DurableTask {
     private static final Logger LOGGER = Logger.getLogger(FileMonitoringTask.class.getName());
 
     private static final String COOKIE = "JENKINS_SERVER_COOKIE";
-    
+
     protected static final String BINARY_RESOURCE_PREFIX = "/io/jenkins/plugins/lib-durable-task/durable_task_monitor_";
 
     /** Value of {@link #charset} used to mean the node’s system default. */
@@ -265,6 +265,9 @@ public abstract class FileMonitoringTask extends DurableTask {
          * Only used if {@link #writeLog(FilePath, OutputStream)} is used; not used for {@link #watch}.
          */
         private long lastLocation;
+        
+        /** Store the cookie value for JENKINS_SERVER_COOKIE */
+        private String cookieValue;
 
         /** @see FileMonitoringTask#charset */
         private @CheckForNull String charset;
@@ -299,6 +302,7 @@ public abstract class FileMonitoringTask extends DurableTask {
             } else {
                 controlDir = null;
             }
+            cookieValue = cookieFor(ws);
         }
 
         @Override public final boolean writeLog(FilePath workspace, OutputStream sink) throws IOException, InterruptedException {
@@ -466,8 +470,10 @@ public abstract class FileMonitoringTask extends DurableTask {
         }
 
         @Override public final void stop(FilePath workspace, Launcher launcher) throws IOException, InterruptedException {
-            launcher.kill(Collections.singletonMap(COOKIE, cookieFor(workspace)));
-            launcher.kill(Collections.singletonMap(COOKIE, cookieFor(workspace, true))); // To maintain backward compatibility
+            if (cookieValue == null) {
+                cookieValue = cookieFor(workspace, true); // To maintain backward compatibility
+            }
+            launcher.kill(Collections.singletonMap(COOKIE, cookieValue));
         }
 
         @Override public void cleanup(FilePath workspace) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -112,7 +112,7 @@ public abstract class FileMonitoringTask extends DurableTask {
      * launched before the new format was applied.
      * @param workspace - workspace path used to setup the digest
      * @param old - boolean to select if we want to use former/old hash algorithm to maintain backward compatibility
-     * @return
+     * @return the cookie value
      */
     private static String cookieFor(FilePath workspace, boolean old) {
         String remote = workspace.getRemote();
@@ -266,7 +266,7 @@ public abstract class FileMonitoringTask extends DurableTask {
          */
         private long lastLocation;
         
-        /** Store the cookie value for JENKINS_SERVER_COOKIE */
+        /** Store the value for {@link #COOKIE} */
         private String cookieValue;
 
         /** @see FileMonitoringTask#charset */

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.durabletask;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.*;
 import hudson.util.ListBoxModel;
@@ -107,7 +108,7 @@ public final class PowershellScript extends FileMonitoringTask {
 
         FilePath nodeRoot = getNodeRoot(ws);
         AgentInfo agentInfo = getAgentInfo(nodeRoot);
-        PowershellController c = new PowershellController(ws);
+        PowershellController c = new PowershellController(ws, envVars.get(COOKIE));
 
         List<String> powershellArgs = new ArrayList<>();
         if (!loadProfile) {
@@ -305,8 +306,8 @@ public final class PowershellScript extends FileMonitoringTask {
     }
 
     private static final class PowershellController extends FileMonitoringController {
-        private PowershellController(FilePath ws) throws IOException, InterruptedException {
-            super(ws, cookieFor(ws));
+        private PowershellController(FilePath ws, @NonNull String cookieValue) throws IOException, InterruptedException {
+            super(ws, cookieValue);
         }
 
         public FilePath getPowerShellScriptFile(FilePath ws) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -306,7 +306,7 @@ public final class PowershellScript extends FileMonitoringTask {
 
     private static final class PowershellController extends FileMonitoringController {
         private PowershellController(FilePath ws) throws IOException, InterruptedException {
-            super(ws);
+            super(ws, cookieFor(ws));
         }
 
         public FilePath getPowerShellScriptFile(FilePath ws) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -163,7 +163,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
 
     private static final class BatchController extends FileMonitoringController {
         private BatchController(FilePath ws) throws IOException, InterruptedException {
-            super(ws);
+            super(ws, cookieFor(ws));
         }
 
         public FilePath getBatchFile1(FilePath ws) throws IOException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/WindowsBatchScript.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.durabletask;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -82,7 +83,7 @@ public final class WindowsBatchScript extends FileMonitoringTask {
             throw new IOException("Batch scripts can only be run on Windows nodes");
         }
 
-        BatchController c = new BatchController(ws);
+        BatchController c = new BatchController(ws, envVars.get(COOKIE));
 
         List<String> launcherCmd = null;
         FilePath binary;
@@ -162,8 +163,8 @@ public final class WindowsBatchScript extends FileMonitoringTask {
     }
 
     private static final class BatchController extends FileMonitoringController {
-        private BatchController(FilePath ws) throws IOException, InterruptedException {
-            super(ws, cookieFor(ws));
+        private BatchController(FilePath ws, @NonNull String cookieValue) throws IOException, InterruptedException {
+            super(ws, cookieValue);
         }
 
         public FilePath getBatchFile1(FilePath ws) throws IOException, InterruptedException {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Description
There is no particular security concern here, but some analyzers flag using MD5 as problematic. So, proposing to switch to SHA-256 and trying to keep backward compatibility on stoping tasks which cookie was hashed with MD5 (`JENKINS_SERVER_COOKIE`)

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
