### PR TITLE
[JENKINS-68080] `FilePath.actAsync` is dangerous and not necessary in `FileMonitoringController.watch`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -545,7 +545,7 @@ public abstract class FileMonitoringTask extends DurableTask {
         }
 
         @Override public void watch(FilePath workspace, Handler handler, TaskListener listener) throws IOException, InterruptedException, ClassCastException {
-            workspace.actAsync(new StartWatching(this, handler, listener));
+            workspace.act(new StartWatching(this, handler, listener));
             LOGGER.log(Level.FINE, "started asynchronous watch in {0}", controlDir);
         }
 


### PR DESCRIPTION
Exposes an error otherwise swallowed; see https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/212. If a `Callable` passed to `actAsync` throws an exception, and no one pays any attention to the resulting `Future`, it will never be reported. In this case the `Callable` just posted a task to an executor pool, so there was little reason to use `actAsync` to begin with; saves a tiny bit of round-trip time (even `actAsync` waits until the message has been delivered!) but makes debugging harder.
