### PR TITLE
[JENKINS-70428] binary wrapper for linux ppc64le and aarch64

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/AgentInfo.java
@@ -120,12 +120,30 @@ public final class AgentInfo implements Serializable {
                 }
             }
 
-            // Note: This will only determine the architecture bits of the JVM.
-            String bits = System.getProperty("sun.arch.data.model");
-            if (bits.equals("64") || bits.equals("32")) {
-                archType += bits;
+            if (os == OsType.LINUX) {
+                archType = arch;
+                switch (arch) {
+                	case "aarch64":
+                	case "ppc64le":
+                		archType = arch;
+                		break;
+                	case "amd64":
+                		archType = "64";
+                		break;
+                	case "x86":
+                		archType = "32";
+                		break;
+                	default:
+                		archType = NOT_SUPPORTED;
+                }
             } else {
-                archType += NOT_SUPPORTED;
+                // Note: This will only determine the architecture bits of the JVM.
+                String bits = System.getProperty("sun.arch.data.model");
+	            if (bits.equals("64") || bits.equals("32")) {
+	                archType += bits;
+	            } else {
+	                archType += NOT_SUPPORTED;
+	            }
             }
 
             boolean binaryCompatible;


### PR DESCRIPTION
ensure that for linux on ppc64le or aarch64 the proper binary wrapper is used.
Also ensure that for not supported linux architectures binarycompatible returns false

Depends on https://github.com/jenkinsci/lib-durable-task/pull/66

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
