### PR TITLE
More efficient `lastLocation` handling in watch mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,4 +73,22 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <dependencies>
+                        <!-- https://github.com/jenkinsci/plugin-pom/pull/560#issuecomment-1656232490 -->
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>${maven-surefire-plugin.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -130,6 +130,7 @@ public class BourneShellScriptTest {
     @Before public void prepareAgentForPlatform() throws Exception {
         switch (platform) {
             case ON_CONTROLLER:
+                BourneShellScript.USE_BINARY_WRAPPER = true;
                 s = j.jenkins;
                 break;
             case NATIVE:
@@ -212,6 +213,7 @@ public class BourneShellScriptTest {
     @Test public void smokeTest() throws Exception {
         int sleepSeconds;
         switch (platform) {
+            case ON_CONTROLLER:
             case NATIVE:
                 sleepSeconds = 0;
                 break;
@@ -438,6 +440,7 @@ public class BourneShellScriptTest {
     @Test public void backgroundLaunch() throws IOException, InterruptedException {
         int sleepSeconds;
         switch (platform) {
+            case ON_CONTROLLER:
             case NATIVE:
             case CENTOS:
             case UBUNTU:
@@ -483,6 +486,7 @@ public class BourneShellScriptTest {
         String os;
         String architecture;
         switch (platform) {
+            case ON_CONTROLLER:
             case NATIVE:
                 if (Platform.isDarwin()) {
                     os = "darwin";
@@ -608,6 +612,7 @@ public class BourneShellScriptTest {
     private String setPsFormat() {
         String cmdCol = null;
         switch (platform) {
+            case ON_CONTROLLER:
             case NATIVE:
                 cmdCol = Platform.isDarwin() ? "comm" : "cmd";
                 break;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -513,7 +513,7 @@ public class BourneShellScriptTest {
         String version = j.getPluginManager().getPlugin("durable-task").getVersion();
         version = StringUtils.substringBefore(version, "-");
         String binaryName = "durable_task_monitor_" + version + "_" + os + "_" + architecture;
-        FilePath binaryPath = ws.getParent().getParent().child("caches/durable-task/" + binaryName);
+        FilePath binaryPath = s.getRootPath().child("caches/durable-task/" + binaryName);
         assertFalse(binaryPath.exists());
 
         BourneShellScript script = new BourneShellScript("echo hello");


### PR DESCRIPTION
Since the task recurs every 100ms, it seems unnecessary to read a file that we just wrote to disk.