### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.72</version>
+        <version>4.74</version>
         <relativePath />
     </parent>
     <artifactId>durable-task</artifactId>


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

Java 11 will be unsupported by Eclipse Temurin and some other Java providers in October 2024. We'll need to move past Java 11 by that time. It does not change the supported Java version or the byte code that is being generated. This intentionally does not include Java 11 in the test configuration because Java 11 byte code is being generated by the Java 17 and Java 21 compilation and because Java 11 is being tested at least weekly by the plugin bill of materials.

Supersedes the following pull request:

* #195

### Testing done

Confirmed tests pass with Java 21 on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
