### PR TITLE
[JENKINS-72436] `sh` step on z/OS with `encoding` set to UTF-8 hangs when trying to read `jenkins-result.txt`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -283,7 +283,7 @@ public final class BourneShellScript extends FileMonitoringTask {
         private ShellController(FilePath ws, boolean zOsFlag, @NonNull String cookieValue, String jenkinsResultTxtEncoding) throws IOException, InterruptedException {
             super(ws, cookieValue);
             this.isZos = zOsFlag;
-            this.jenkinsResultTxtEncoding = jenkinsResultTxtEncoding == null ? getCharset() : jenkinsResultTxtEncoding;
+            this.jenkinsResultTxtEncoding = jenkinsResultTxtEncoding;
         }
 
         public FilePath getScriptFile(FilePath ws) throws IOException, InterruptedException {
@@ -300,7 +300,7 @@ public final class BourneShellScript extends FileMonitoringTask {
             if(isZos) {
                 // We need to transcode status file from EBCDIC only on z/OS platform
                 FilePath statusFile = getResultFile(workspace);
-                status = statusFile.act(new StatusCheckWithEncoding(jenkinsResultTxtEncoding));
+                status = statusFile.act(new StatusCheckWithEncoding(jenkinsResultTxtEncoding != null ? jenkinsResultTxtEncoding : getCharset()));
             }
             else {
                 status = super.exitStatus(workspace, listener);

--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -390,8 +390,7 @@ public final class BourneShellScript extends FileMonitoringTask {
                         }
                     }
                 } catch (NumberFormatException x) {
-                    LOGGER.log(Level.WARNING, "corrupted content in {0} when reading with charset {1}: {2}", new Object[] {f, charset, x});
-                    throw new IOException("corrupted content in " + f + ": " + x, x);
+                    throw new IOException("corrupted content in " + f + " using " + charset + ": " + x, x);
                 }
             }
             return null;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixing [JENKINS-72436](https://issues.jenkins.io/browse/JENKINS-72436)

When running on z/OS always use the system's encoding  for reading file jenkins-result.txt. System's encoding is provided in system property ibm.system.encoding. 
No change in behavior for any other operating system. 

### Testing done
Successfully tested on a z/OS node the following pipeline:
```
pipeline {
    agent{node('zOS-node')}
    stages {
        stage('example for bugreport')   {
            steps {
                sh(script:'''#!/bin/sh -e
                    echo "UTF-8 output" | iconv -f 1047 -t utf-8''', 
                    encoding:'UTF-8')
                sh 'echo "native output"'
            }
        }
    }
}
```

Test pipeline output:
```
[Pipeline] // stage
[Pipeline] withEnv
[Pipeline] {
[Pipeline] stage
[Pipeline] { (example for bugreport)
[Pipeline] sh
UTF-8 output
[Pipeline] sh
+ echo native output 
native output
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```

No automated tests for z/OS.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
