### PR TITLE
Switch from CentOS to UBI

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/CentOSFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/CentOSFixture.java
@@ -28,6 +28,6 @@ import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 
-/** Analogue of {@link JavaContainer} but using CentOS rather than Ubuntu. */
+/** Analogue of {@link JavaContainer} but using UBI (formerly CentOS) rather than Ubuntu. */
 @DockerFixture(id = "centos", ports = 22)
 public class CentOSFixture extends DockerContainer {}

--- a/src/test/resources/org/jenkinsci/plugins/durabletask/CentOSFixture/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/durabletask/CentOSFixture/Dockerfile
@@ -1,7 +1,8 @@
-FROM centos:7.9.2009
+FROM registry.access.redhat.com/ubi9/ubi
 RUN yum -y install \
         openssh-server \
-        java-11-openjdk-headless \
+        java-21-openjdk-headless \
+        procps-ng \
     && yum clean all
 RUN ssh-keygen -A
 RUN useradd test -d /home/test && \


### PR DESCRIPTION
Tests started failing recently in this plugin, e.g. https://github.com/jenkinsci/durable-task-plugin/pull/220/checks?check_run_id=28221800550 (#220). This seems to be due to a CentOS EOL https://github.com/docker-library/official-images/pull/17094. For purposes of these tests, we just care about general distro flavor, so using UBI is close enough.

Tested locally with:

```bash
mvnd test -Dtest='BourneShellScriptTest#*[3: CENTOS]'
```
