### PR TITLE
No need for an explicit dep on Hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-             <groupId>org.hamcrest</groupId>
-             <artifactId>hamcrest</artifactId>
-             <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.2.1</version>


### PR DESCRIPTION
https://github.com/jenkinsci/durable-task-plugin/pull/222#pullrequestreview-2219707164 https://github.com/jenkinsci/durable-task-plugin/pull/223 Normally included in all plugins via `jenkins-test-harness`, and in this case also via `awaitility`.