### PR TITLE
Handle unsigned int errorcodes more gracefully in Windows Batch

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -393,7 +393,12 @@ public abstract class FileMonitoringTask extends DurableTask {
                         return null;
                     } else {
                         try {
-                            return Integer.valueOf(text);
+                            long value = Long.parseLong(text);
+                            if (value > Integer.MAX_VALUE) {
+                                LOGGER.warning("ErrorCode greater than max integer detected, limited to max value");
+                                value = Integer.MAX_VALUE;
+                            }
+                            return (Integer) (int) value;
                         } catch (NumberFormatException x) {
                             throw new IOException("corrupted content in " + f + ": " + x, x);
                         }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/WindowsBatchScriptTest.java
@@ -114,6 +114,22 @@ public class WindowsBatchScriptTest {
         c.cleanup(ws);
     }
 
+    @Test public void exitCommandUnsignedInt() throws Exception {
+        Controller c = new WindowsBatchScript("echo hello world\r\nexit 3221225477").launch(new EnvVars(), ws, launcher, listener);
+        awaitCompletion(c);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        c.writeLog(ws, baos);
+        if (enableBinary) {
+            assertEquals(Integer.valueOf(Integer.MAX_VALUE), c.exitStatus(ws, launcher, listener));
+        } else {
+            assertEquals(Integer.valueOf(-1073741819), c.exitStatus(ws, launcher, listener));
+        }
+
+        String log = baos.toString();
+        assertTrue(log, log.contains("hello world"));
+        c.cleanup(ws);
+    }
+
     @Test public void exitBCommandAfterError() throws Exception {
         Controller c = new WindowsBatchScript("cmd /c exit 42\r\nexit /b").launch(new EnvVars(), ws, launcher, listener);
         awaitCompletion(c);


### PR DESCRIPTION
We have a job on a Windows machine which executes a Matlab project within a batch-file, and has actually a quite high error code of `3221225477`. We are using the binary wrapper, and so this quite high number gets written into the text file. The parsing fails with an `IOException` and the connection gets lost to the agent. I was first confused, but actually windows uses an unsigned int for the error codes, as documented [here](https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-seterrormode). I decided to set it to max integer, which is from my point of view better than throwing the exception, but I added a warning log message about it.

### Testing done

Added a unit test which reproduces the error and verifies that it is resolved like this.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
