### PR TITLE
Use method in remoting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -580,21 +580,6 @@ public abstract class FileMonitoringTask extends DurableTask {
 
     }
 
-    // TODO https://github.com/jenkinsci/remoting/pull/657
-    private static boolean isClosedChannelException(Throwable t) {
-        if (t instanceof ClosedChannelException) {
-            return true;
-        } else if (t instanceof ChannelClosedException) {
-            return true;
-        } else if (t instanceof EOFException) {
-            return true;
-        } else if (t == null) {
-            return false;
-        } else {
-            return isClosedChannelException(t.getCause()) || Stream.of(t.getSuppressed()).anyMatch(FileMonitoringTask::isClosedChannelException);
-        }
-    }
-
     private static class Watcher implements Runnable {
 
         private final FileMonitoringController controller;
@@ -667,7 +652,7 @@ public abstract class FileMonitoringTask extends DurableTask {
                 }
             } catch (Exception x) {
                 // note that LOGGER here is going to the agent log, not master log
-                if (isClosedChannelException(x)) {
+                if (Channel.isClosedChannelException(x)) {
                     LOGGER.warning(() -> this + " giving up on watching " + controller.controlDir);
                 } else {
                     LOGGER.log(Level.WARNING, this + " giving up on watching " + controller.controlDir, x);


### PR DESCRIPTION
Stumbled upon a TODO and make use of static method of remoting, which was integrated in [remoting PR657](https://github.com/jenkinsci/remoting/pull/657)

### Testing done

Only maven compile. Waiting if a test fails in CI.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
