### PR TITLE
[JENKINS-33708] Do not call `nohup` for `sh` steps running on Windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -263,7 +263,7 @@ public final class BourneShellScript extends FileMonitoringTask {
 
         cmdString = cmdString.replace("$", "$$"); // escape against EnvVars jobEnv in LocalLauncher.launch
         List<String> cmd = new ArrayList<>();
-        if (os != OsType.DARWIN) { // JENKINS-25848
+        if (os != OsType.DARWIN && os != OsType.WINDOWS) { // JENKINS-25848  JENKINS-33708
             cmd.add("nohup");
         }
         if (LAUNCH_DIAGNOSTICS) {


### PR DESCRIPTION
see https://issues.jenkins.io/browse/JENKINS-33708 discussion.
