### PR TITLE
[JENKINS-75512] Ensure SIGPIPE is not hidden when calling shell script to avoid hanging.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -264,7 +264,11 @@ public final class BourneShellScript extends FileMonitoringTask {
         cmdString = cmdString.replace("$", "$$"); // escape against EnvVars jobEnv in LocalLauncher.launch
         List<String> cmd = new ArrayList<>();
         if (os != OsType.DARWIN && os != OsType.WINDOWS) { // JENKINS-25848  JENKINS-33708
-            cmd.add("nohup");
+            // Some java implementation do block SIGPIPE signal by default, so make sure the default
+            // signal handler is used to avoid having commands hanging for ever.
+            // env --default-signal=SIGPIPE was introduced in coreutils 8.31 released in 2019,
+            // so cope with old OS not supporting this.
+            cmd.addAll(Arrays.asList("sh", "-c", "if env --default-signal=SIGPIPE true 1>/dev/null 2>&1; then exec env --default-signal=SIGPIPE \"$@\"; else exec \"$@\"; fi", "--", "nohup"));
         }
         if (LAUNCH_DIAGNOSTICS) {
             cmd.addAll(Arrays.asList("sh", "-c", cmdString));


### PR DESCRIPTION
This change aims at fixing the hanging issue we hit when using a JDK 21 agent image to run Jenkins and some `sh` command that require SIGPIPE to work fine in order to finish. See the example of such a command in the ticket JENKINS-75512 as well as explanations.

Here we wrap the call to `nohup` by a call to `env --default-signal=SIGPIPE` to avoid this issue. Since not all Linux distro will support `env --default-signal=SIGPIPE` (this flag was introduced in 2019 in coreutils), wrap this in some more complex shell command to be able to fallback to not using `env` at all if the OS doesn't support it.

### Testing done

The details of the testing done is in the ticket JENKINS-75512 (checked via commands run inside a fedora container).

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [N/A] Ensure you have provided tests - that demonstrates feature works or fixes the issue