### PR TITLE
Flake in `OnceRetentionStrategyTest.deadConnectionsShouldReLaunched` after `DurableTaskStep` change

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategyTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 
 public class OnceRetentionStrategyTest {
 
@@ -68,6 +69,8 @@ public class OnceRetentionStrategyTest {
         // (because the ping command and its parent cmd.exe get killed :-o )
         WindowsBatchScript.USE_BINARY_WRAPPER=true; 
         BourneShellScript.USE_BINARY_WRAPPER=true;
+        // Longer than retention strategy idle time, shorter than test timeout (default 5m in prod but only 15s in test):
+        ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS = Duration.ofMinutes(2).toMillis();
     }
 
     @Test


### PR DESCRIPTION
Test introduced in #152 became unstable as of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/463. Actually I am glad to be reminded of this old PR as it showed that until a year ago even an outbound cloud agent using the _recommended_ retention strategy could suffer from a permanent build hang as a result of a broken socket, suggesting that there are likely multiple flawed retention strategies floating around.