### PR TITLE
Remove usages of `StringUtils`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java
@@ -50,7 +50,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.durabletask.AgentInfo.OsType;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/FileMonitoringTask.java
@@ -82,7 +82,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.commons.io.output.WriterOutputStream;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.remoting.util.IOUtils;
 
 /**
@@ -199,7 +198,10 @@ public abstract class FileMonitoringTask extends DurableTask {
         if (durablePlugin == null) {
             throw new IOException("Unable to find durable task plugin");
         }
-        String pluginVersion = StringUtils.substringBefore(durablePlugin.getVersion(), "-");
+        String pluginVersion = durablePlugin.getVersion();
+        if (pluginVersion != null && pluginVersion.contains("-")) {
+            pluginVersion = pluginVersion.substring(0, pluginVersion.indexOf("-"));
+        }
         AgentInfo agentInfo = nodeRoot.act(new AgentInfo.GetAgentInfo(pluginVersion));
 
         return agentInfo;

--- a/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/PowershellScript.java
@@ -38,7 +38,6 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -68,7 +68,6 @@ import org.apache.commons.io.output.TeeOutputStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.test.acceptance.docker.Docker;
 import org.jenkinsci.test.acceptance.docker.DockerContainer;
 import org.jenkinsci.test.acceptance.docker.DockerRule;
@@ -523,7 +522,9 @@ public class BourneShellScriptTest {
         }
 
         String version = j.getPluginManager().getPlugin("durable-task").getVersion();
-        version = StringUtils.substringBefore(version, "-");
+        if (version != null && version.contains("-")) {
+            version = version.substring(0, version.indexOf("-"));
+        }
         String binaryName = "durable_task_monitor_" + version + "_" + os + "_" + architecture;
         FilePath binaryPath = s.getRootPath().child("caches/durable-task/" + binaryName);
         assertFalse(binaryPath.exists());


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this functionality natively.