### PR TITLE
Adjusted fine logging on `ContinuedTask`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTask.java
@@ -73,7 +73,7 @@ public interface ContinuedTask extends Queue.Task {
                         LOGGER.log(Level.FINER, "{0}’s label {1} does not match {2}", new Object[] {other.task, label, node});
                     }
                 } else {
-                    LOGGER.log(Level.FINER, "{0} is not continued, so it would not block {1}", new Object[] {other.task, item.task});
+                    LOGGER.finer(() -> other.task + " is not continued, so it would not block " + item.task);
                 }
             }
             LOGGER.log(Level.FINER, "no reason to block {0}", item.task);


### PR DESCRIPTION
While testing a (CloudBees CI HA) controller under load with a lot of permanent agents and a lot of running builds, I noticed that after a restart the controller was extremely slow and often the `Queue` lock was held by `ContinuedTask` logging (this component was not enabled for logging):

```
"AtmostOneTaskExecutor[Periodic Jenkins queue maintenance] [#520]" #7089 [7119] daemon prio=5 os_prio=0 cpu=11860.99ms elapsed=561.58s tid=0x00007fb581ae8f70 nid=7119 runnable  [0x00007fb50f2f0000]
   java.lang.Thread.State: RUNNABLE
	at org.jenkinsci.plugins.durabletask.executors.ContinuedTask$Scheduler.canTake(ContinuedTask.java:76)
	at hudson.model.Queue$JobOffer.getCauseOfBlockage(Queue.java:280)
	at hudson.model.Queue.maintain(Queue.java:1656)
	at hudson.model.Queue$1.call(Queue.java:334)
	at hudson.model.Queue$1.call(Queue.java:331)
	at jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:109)
	at jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:99)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.util.concurrent.FutureTask.run(java.base@21.0.8/FutureTask.java:317)
	at hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
	at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)
```

or

```
"jenkins.util.Timer [#9]" #59 [87] daemon prio=5 os_prio=0 cpu=23765.74ms elapsed=2574.05s tid=0x00007fb56400db30 nid=87 runnable  [0x00007fb5fe0d3000]
   java.lang.Thread.State: RUNNABLE
	at org.jenkinsci.plugins.durabletask.executors.ContinuedTask$Scheduler.canTake(ContinuedTask.java:76)
	at hudson.model.Queue$JobOffer.getCauseOfBlockage(Queue.java:280)
	at hudson.model.Queue.maintain(Queue.java:1656)
	at hudson.model.Queue$MaintainTask.doRun(Queue.java:2927)
	at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:92)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:67)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21.0.8/Executors.java:572)
	at java.util.concurrent.FutureTask.runAndReset(java.base@21.0.8/FutureTask.java:358)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@21.0.8/ScheduledThreadPoolExecutor.java:305)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.8/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.8/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)
```

Tried again with this patch and I did not see any mention of `ContinuedTask`, though that is weak evidence since it is unclear how this could be reproduced.
