### PR TITLE
Dropping `Queue` lock from `OnceRetentionStrategy.done`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/executors/OnceRetentionStrategy.java
@@ -134,20 +134,18 @@ public final class OnceRetentionStrategy extends CloudRetentionStrategy implemen
         }
         LOGGER.log(Level.FINE, new Throwable(), () -> "terminating " + c + " idle? " + c.isIdle() + " idleStartMilliseconds=" + new Date(c.getIdleStartMilliseconds()));
         Computer.threadPoolForRemoting.submit(() -> {
-            Queue.withLock(() -> {
-                try {
-                    AbstractCloudSlave node = c.getNode();
-                    if (node != null) {
-                        LOGGER.fine(() -> "terminating " + c + " now");
-                        node.terminate();
-                    }
-                } catch (InterruptedException | IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
-                    synchronized (OnceRetentionStrategy.this) {
-                        terminating = false;
-                    }
+            try {
+                AbstractCloudSlave node = c.getNode();
+                if (node != null) {
+                    LOGGER.fine(() -> "terminating " + c + " now");
+                    node.terminate();
                 }
-            });
+            } catch (InterruptedException | IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to terminate " + c.getName(), e);
+                synchronized (OnceRetentionStrategy.this) {
+                    terminating = false;
+                }
+            }
         });
     }
 


### PR DESCRIPTION
`AbstractCloudSlave._terminate` is a potentially slow process (as suggested by the `IOException` / `InterruptedException` in its signature). For example `KubernetesSlave.deleteSlavePod` waits for a response from the API server, which might be overloaded and hanging. In the meantime the Jenkins queue lock is held (as of #2) which can cause everything else in the system to hang.

I tried to follow the justification in https://issues.jenkins.io/browse/JENKINS-26380 without success. The original issue was about a deadlock when `done` directly called `terminate`. That is addressed by backgrounding in `threadPoolForRemoting`. Then there was a lot of discussion about possible fixes in different places. The most relevant explanation seems to be

> builds being scheduled and then failing on a node that does not exist... all paths identified that the nodes were being removed **while** the queue maintenance was in progress, thus you should not remove nodes concurrent with the queue being maintained, instead you need to get the Queue's lock, confirm that the node is truly idle and then remove it all while holding the Queue's lock... and even that has issues... as the job can be scheduled but not started... so actually you mark the node as no longer accepting tasks, release the lock, sleep 100ms, re-acquire the lock and then double check it's idle and only then do you remove the node

But `OnceRetentionStrategy` already called `setAcceptingTasks(false)` which should be blocking other tasks from being scheduled onto this agent. (Inside `Executor.finish1`, called before `Computer.removeExecutor` in `finish2` which acquires the queue lock and which IIUC would mark the agent as idle.) There should be no need to check idleness of the agent—it is illegal to use this agent more than once (hence the name).
