### PR TITLE
`assumeDocker` at the right times

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -122,7 +122,6 @@ abstract class BourneShellScriptTest {
     }
 
     protected Node createNode() throws Exception {
-        assumeDocker();
         SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(
                 Domain.global(), Collections.singletonList(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "test", "test"))));
         var sshLauncher = new SSHLauncher(container.getHost(), container.getMappedPort(22), "test");
@@ -151,6 +150,7 @@ abstract class BourneShellScriptTest {
 
         container = createContainer();
         if (container != null) {
+            assumeDocker();
             container.start();
         }
 


### PR DESCRIPTION
Amending #274: https://github.com/jenkinsci/bom/pull/5906#issuecomment-3487492479

Tested locally via `mvnd test` with my Docker daemon disabled—errors without this patch, a bunch of skips as expected with it. Enabling it again, I was able to run some representative Docker-based tests (the full suite would take a while).