### PR TITLE
Skip `assertNoZombies` check on non-Docker-based tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptTest.java
@@ -514,6 +514,9 @@ abstract class BourneShellScriptTest {
         String exitString;
         String zombieString;
         switch (platform) {
+            case ON_CONTROLLER:
+            case NATIVE:
+                return; // cannot control the CI environment
             case SLIM:
                 // Debian slim does not have ps
             case NO_INIT:


### PR DESCRIPTION
Like #301, amending #291 & #274. As far as I can tell the issue in https://github.com/jenkinsci/bom/pull/5931#issuecomment-3496500291 is that the zombie process check works on the VM-based agents used in this plugin’s own CI but fails in the K8s agents used by `bom` CI. Unclear why this would be failing now. At any rate, the non-Docker-based tests run in an undefined Linux host environment which we cannot control, whereas the zombie check was intended to correct a regression in a containerized agent.