### PR TITLE
Update test fixtures to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>1.21.3</version>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <version>2.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptNoInitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/BourneShellScriptNoInitTest.java
@@ -41,6 +41,6 @@ class BourneShellScriptNoInitTest extends BourneShellScriptTest {
         assumeDocker();
         return new DumbSlave("docker",
                 "/home/jenkins/agent",
-                new SimpleCommandLauncher("docker run -i --rm jenkins/agent:latest-jdk17 java -jar /usr/share/jenkins/agent.jar"));
+                new SimpleCommandLauncher("docker run -i --rm jenkins/agent:latest-jdk21 java -jar /usr/share/jenkins/agent.jar"));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/PowerShellCoreFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/PowerShellCoreFixture.java
@@ -6,7 +6,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import java.util.List;
 
 public class PowerShellCoreFixture extends GenericContainer<PowerShellCoreFixture> {
-    public static final String PWSH_JAVA_LOCATION = "/usr/lib/jvm/java-17-openjdk-amd64/bin/java";
+    public static final String PWSH_JAVA_LOCATION = "/usr/lib/jvm/java-21-openjdk-amd64/bin/java";
 
     public PowerShellCoreFixture() {
         super(new ImageFromDockerfile("pwsh", false)

--- a/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/SlimFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/SlimFixture.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class SlimFixture extends GenericContainer<SlimFixture> {
 
-    public static final String SLIM_JAVA_LOCATION = "/usr/lib/jvm/java-17-openjdk-amd64/bin/java";
+    public static final String SLIM_JAVA_LOCATION = "/usr/lib/jvm/java-21-openjdk-amd64/bin/java";
 
     public SlimFixture() {
         super(new ImageFromDockerfile("slim", false)

--- a/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/AlpineFixture/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/AlpineFixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/agent:alpine-jdk17
+FROM jenkins/agent:alpine-jdk21
 USER root
 RUN apk add --upgrade --update --no-cache openssh
 RUN ssh-keygen -A

--- a/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/PowerShellCoreFixture/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/PowerShellCoreFixture/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/powershell:ubuntu-jammy
 RUN apt-get update -y && \
     apt-get install -y \
         openssh-server \
-        openjdk-17-jre-headless \
+        openjdk-21-jre-headless \
         locales
 # openssh installs procps, and thus /bin/ps, as a dependency, so to reproduce JENKINS-52881 we need to delete it:
 RUN dpkg --force-depends -r procps

--- a/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/SlimFixture/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/SlimFixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:12-slim
+FROM debian:13-slim
 RUN apt-get update -y && \
     apt-get install -y \
-        openjdk-17-jre-headless \
+        openjdk-21-jre-headless \
         openssh-server \
         locales
 # openssh installs procps, and thus /bin/ps, as a dependency, so to reproduce JENKINS-52881 we need to delete it:

--- a/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/UbuntuFixture/Dockerfile
+++ b/src/test/resources/org/jenkinsci/plugins/durabletask/fixtures/UbuntuFixture/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:noble
 RUN apt-get update -y && \
     apt-get install -y \
-        openjdk-17-jre-headless \
+        openjdk-21-jre-headless \
         openssh-server \
         locales
 RUN mkdir -p /var/run/sshd


### PR DESCRIPTION
Needed in order to test PCT `-Djenkins.version=2.545`.