### PR TITLE
Choose better names for `ImageFromDockerfile` images

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/AlpineFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/AlpineFixture.java
@@ -36,7 +36,7 @@ public class AlpineFixture extends GenericContainer<AlpineFixture> {
     public static final String ALPINE_JAVA_LOCATION = "/opt/java/openjdk/bin/java";
 
     public AlpineFixture() {
-        super(new ImageFromDockerfile("alpine", false)
+        super(new ImageFromDockerfile("localhost/testcontainers/durable-task/alpine", false)
                 .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/durabletask/fixtures/AlpineFixture/Dockerfile"));
         setExposedPorts(List.of(22));
     }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/CentOSFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/CentOSFixture.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class CentOSFixture extends GenericContainer<CentOSFixture> {
 
     public CentOSFixture() {
-        super(new ImageFromDockerfile("centos", false)
+        super(new ImageFromDockerfile("localhost/testcontainers/durable-task/centos", false)
                 .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/durabletask/fixtures/CentOSFixture/Dockerfile"));
         setExposedPorts(List.of(22));
     }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/PowerShellCoreFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/PowerShellCoreFixture.java
@@ -9,7 +9,7 @@ public class PowerShellCoreFixture extends GenericContainer<PowerShellCoreFixtur
     public static final String PWSH_JAVA_LOCATION = "/usr/lib/jvm/java-25-openjdk-amd64/bin/java";
 
     public PowerShellCoreFixture() {
-        super(new ImageFromDockerfile("pwsh", false)
+        super(new ImageFromDockerfile("localhost/testcontainers/durable-task/pwsh", false)
                 .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/durabletask/fixtures/PowerShellCoreFixture/Dockerfile"));
         setExposedPorts(List.of(22));
     }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/SlimFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/SlimFixture.java
@@ -37,7 +37,7 @@ public class SlimFixture extends GenericContainer<SlimFixture> {
     public static final String SLIM_JAVA_LOCATION = "/usr/lib/jvm/java-25-openjdk-amd64/bin/java";
 
     public SlimFixture() {
-        super(new ImageFromDockerfile("slim", false)
+        super(new ImageFromDockerfile("localhost/testcontainers/durable-task/slim", false)
                 .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/durabletask/fixtures/SlimFixture/Dockerfile"));
         setExposedPorts(List.of(22));
     }

--- a/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/UbuntuFixture.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/fixtures/UbuntuFixture.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class UbuntuFixture extends GenericContainer<UbuntuFixture> {
 
     public UbuntuFixture() {
-        super(new ImageFromDockerfile("ubuntu", false)
+        super(new ImageFromDockerfile("localhost/testcontainers/durable-task/ubuntu", false)
                 .withFileFromClasspath("Dockerfile", "org/jenkinsci/plugins/durabletask/fixtures/UbuntuFixture/Dockerfile"));
         setExposedPorts(List.of(22));
     }


### PR DESCRIPTION
#561 failed I think for the same reason as #547: it was trying to overwrite `docker.io/library/ubuntu:latest` locally.