### PR TITLE
Performance: Avoid allocation if log level > finer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTask.java
@@ -30,6 +30,8 @@ import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -58,24 +60,34 @@ public interface ContinuedTask extends Queue.Task {
         }
 
         @Override public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+            // as this method can be a hostspot, do not use a Supplier in logging statements
+            // rather guard the logging statement inside an if
+            final boolean isFiner = LOGGER.isLoggable(Level.FINER);
             if (isContinued(item.task)) {
-                LOGGER.finer(() -> item.task + " is a continued task, so we are not blocking it");
+                if (isFiner) {
+                    LOGGER.finer(item.task + " is a continued task, so we are not blocking it");
+                }
                 return null;
             }
+            final boolean isFine = LOGGER.isLoggable(Level.FINE);
             for (Queue.BuildableItem other : Queue.getInstance().getBuildableItems()) {
                 if (isContinued(other.task)) {
                     Label label = other.task.getAssignedLabel();
                     if (label == null || label.matches(node)) { // conservative; might actually go to a different node
-                        LOGGER.fine(() -> "blocking " + item.task + " in favor of " + other.task);
+                        if (isFine) {
+                            LOGGER.fine("blocking " + item.task + " in favor of " + other.task);
+                        }
                         return new HoldOnPlease(other.task);
-                    } else {
-                        LOGGER.finer(() -> other.task + "’s label " + label + " does not match " + node);
+                    } else if (isFiner) {
+                        LOGGER.finer(other.task + "’s label " + label + " does not match " + node);
                     }
-                } else {
-                    LOGGER.finer(() -> other.task + " is not continued, so it would not block " + item.task);
+                } else if (isFiner) {
+                    LOGGER.finer(other.task + " is not continued, so it would not block " + item.task);
                 }
             }
-            LOGGER.finer(() -> "no reason to block " + item.task);
+            if (isFiner) {
+                LOGGER.finer("no reason to block " + item.task);
+            }
             return null;
         }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR stops allocating `Supplier` objects in a hot path if `Level.FINER` is not loggable.

I've been having some performance issues with Jenkins controllers as the queue size and incoming agent connections grow, similar to what's described in #560. 

I profiled with JFR's `settings=profile` configuration, and found 20% of samples over a few hours were in `LOGGER.finer(Supplier)` in this code path. I know sampling isn't perfect and there are more impactful changes described in 560, but I thought this may be a nice first contribution to this plugin - it is a hot path that is allocating a `Supplier` on every iteration of the loop. For anyone who has the root logger set to `INFO`, it'd be better to avoid that allocation since it won't be  logged anyway.

<img width="1164" height="281" alt="Screenshot 2026-05-28 at 20 30 53" src="https://github.com/user-attachments/assets/25dee999-e4f6-43e5-8564-481111b9b002" />


### Testing done

`mvn clean verify` and [JMH Benchmarks](https://github.com/sghill/durable-task-plugin/blob/perf/benchmark/benchmarks/pom.xml#L217-L224) that include the `org.apache.logging.log4j:log4j-jul` bridge I'm using in production. I ran my benchmarks on a Macbook Pro M1 Max with 2 forks, 5 warmup iterations and 10 benchmark iterations.

It showed an improvement of 13% with a queue size of 2000:

<img width="1390" height="539" alt="Screenshot 2026-05-28 at 21 23 07" src="https://github.com/user-attachments/assets/3c347b07-6061-4ecc-b123-7a455e19b617" />


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
