### PR TITLE
feat: short-circuit ContinuedTask.Scheduler.canTake when no continued tasks are buildable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTask.java
+++ b/src/main/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTask.java
@@ -29,8 +29,9 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.QueueListener;
 import hudson.model.queue.QueueTaskDispatcher;
-
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
@@ -55,6 +56,14 @@ public interface ContinuedTask extends Queue.Task {
 
         private static final Logger LOGGER = Logger.getLogger(ContinuedTask.class.getName());
 
+        /**
+         * Number of {@link ContinuedTask} instances currently in the buildable queue.
+         * Tracked by {@link CountingListener} on {@code instanceof ContinuedTask} (stable over the
+         * buildable lifecycle), not on the dynamic {@link ContinuedTask#isContinued()} value.
+         * Drift only causes the fast path to miss; it never produces an incorrect block decision.
+         */
+        private static final AtomicInteger continuedBuildableCount = new AtomicInteger();
+
         private static boolean isContinued(Queue.Task task) {
             return task instanceof ContinuedTask && ((ContinuedTask) task).isContinued();
         }
@@ -67,6 +76,9 @@ public interface ContinuedTask extends Queue.Task {
                 if (isFiner) {
                     LOGGER.finer(item.task + " is a continued task, so we are not blocking it");
                 }
+                return null;
+            }
+            if (continuedBuildableCount.get() == 0) {
                 return null;
             }
             final boolean isFine = LOGGER.isLoggable(Level.FINE);
@@ -89,6 +101,30 @@ public interface ContinuedTask extends Queue.Task {
                 LOGGER.finer("no reason to block " + item.task);
             }
             return null;
+        }
+
+        static int continuedBuildableCount() {
+            return continuedBuildableCount.get();
+        }
+
+        @Extension
+        public static final class CountingListener extends QueueListener {
+            @Override public void onEnterBuildable(Queue.BuildableItem item) {
+                if (item.task instanceof ContinuedTask) {
+                    continuedBuildableCount.incrementAndGet();
+                }
+            }
+            @Override public void onLeaveBuildable(Queue.BuildableItem item) {
+                if (item.task instanceof ContinuedTask) {
+                    int previous = continuedBuildableCount.getAndUpdate(c -> c > 0 ? c - 1 : 0);
+                    if (previous <= 0) {
+                        // Indicates a missed onEnterBuildable or a stray callback. Clamp at 0
+                        // rather than letting the counter drift negative — a negative counter
+                        // would keep the fast path armed forever and silently lose the win.
+                        LOGGER.warning(() -> "ContinuedTask buildable counter underflow on leave of " + item.task + "; clamped at 0");
+                    }
+                }
+            }
         }
 
         private static final class HoldOnPlease extends CauseOfBlockage {

--- a/src/test/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTaskTest.java
+++ b/src/test/java/org/jenkinsci/plugins/durabletask/executors/ContinuedTaskTest.java
@@ -24,12 +24,14 @@
 
 package org.jenkinsci.plugins.durabletask.executors;
 
+import hudson.ExtensionList;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
+import hudson.model.Queue;
 import hudson.model.queue.QueueTaskFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,6 +84,89 @@ class ContinuedTaskTest {
         assertEquals(1, cntB.get());
     }
 
+    @Test
+    void counterTracksContinuedTaskBuildableLifecycle() throws Exception {
+        int initial = ContinuedTask.Scheduler.continuedBuildableCount();
+        long id = j.jenkins.getQueue().schedule(new TestTask(new AtomicInteger(), true), 0).getId();
+        j.jenkins.getQueue().maintain();
+        waitForCounter(initial + 1);
+        assertEquals(initial + 1, ContinuedTask.Scheduler.continuedBuildableCount());
+
+        cancelById(id);
+        j.jenkins.getQueue().maintain();
+        waitForCounter(initial);
+        assertEquals(initial, ContinuedTask.Scheduler.continuedBuildableCount());
+    }
+
+    @Test
+    void counterIgnoresNonContinuedTasks() throws Exception {
+        int initial = ContinuedTask.Scheduler.continuedBuildableCount();
+        long id = j.jenkins.getQueue().schedule(new LabelledMockTask(new AtomicInteger()), 0).getId();
+        j.jenkins.getQueue().maintain();
+        // Give the listener a window to fire if it were buggy.
+        Thread.sleep(200);
+        assertEquals(initial, ContinuedTask.Scheduler.continuedBuildableCount());
+        cancelById(id);
+    }
+
+    @Test
+    void counterClampsAtZeroOnSpuriousLeaveBuildable() throws Exception {
+        // Drive the counter to 1, capture a real BuildableItem, then cancel so the counter goes
+        // back to 0. The retained item reference lets us simulate a duplicate/stray
+        // onLeaveBuildable callback, which must clamp at 0 rather than going negative.
+        long id = j.jenkins.getQueue().schedule(new TestTask(new AtomicInteger(), true), 0).getId();
+        j.jenkins.getQueue().maintain();
+        waitForCounter(1);
+        Queue.BuildableItem captured = (Queue.BuildableItem) j.jenkins.getQueue().getItem(id);
+        cancelById(id);
+        j.jenkins.getQueue().maintain();
+        waitForCounter(0);
+        assertEquals(0, ContinuedTask.Scheduler.continuedBuildableCount());
+
+        // Spurious extra callback: counter would go to -1 without the clamp.
+        ContinuedTask.Scheduler.CountingListener listener =
+                ExtensionList.lookupSingleton(ContinuedTask.Scheduler.CountingListener.class);
+        listener.onLeaveBuildable(captured);
+        assertEquals(0, ContinuedTask.Scheduler.continuedBuildableCount());
+
+        // And again — still clamped.
+        listener.onLeaveBuildable(captured);
+        assertEquals(0, ContinuedTask.Scheduler.continuedBuildableCount());
+    }
+
+    @Test
+    void counterIgnoresLeaveBuildableForNonContinuedTaskAtZero() throws Exception {
+        // Schedule, capture, cancel — same pattern as above, but with a non-ContinuedTask.
+        // The leave callback must not warn (item isn't a ContinuedTask) and the counter must
+        // remain at 0.
+        assertEquals(0, ContinuedTask.Scheduler.continuedBuildableCount());
+        long id = j.jenkins.getQueue().schedule(new LabelledMockTask(new AtomicInteger()), 0).getId();
+        j.jenkins.getQueue().maintain();
+        Queue.BuildableItem captured = (Queue.BuildableItem) j.jenkins.getQueue().getItem(id);
+        cancelById(id);
+
+        ContinuedTask.Scheduler.CountingListener listener =
+                ExtensionList.lookupSingleton(ContinuedTask.Scheduler.CountingListener.class);
+        listener.onLeaveBuildable(captured);
+        assertEquals(0, ContinuedTask.Scheduler.continuedBuildableCount());
+    }
+
+    private void cancelById(long id) {
+        Queue.Item current = j.jenkins.getQueue().getItem(id);
+        if (current != null) {
+            j.jenkins.getQueue().cancel(current);
+        }
+    }
+
+    private static void waitForCounter(int target) throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            if (ContinuedTask.Scheduler.continuedBuildableCount() == target) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+    }
+
     private static final class TestTask extends MockTask implements ContinuedTask {
         private final boolean continued;
 
@@ -103,6 +188,18 @@ class ContinuedTaskTest {
         @Override
         public String toString() {
             return "TestTask:" + continued;
+        }
+    }
+
+    /** Non-ContinuedTask pinned to a label with no agent, so it stays in the queue. */
+    private static final class LabelledMockTask extends MockTask {
+        LabelledMockTask(AtomicInteger cnt) {
+            super(cnt);
+        }
+
+        @Override
+        public Label getAssignedLabel() {
+            return Label.get("nonexistent-counter-test-label");
         }
     }
 


### PR DESCRIPTION
Track the number of buildable ContinuedTask items via a QueueListener so the QueueTaskDispatcher hot path can return immediately in the common case where no continued task is queued, instead of allocating a fresh buildable-items copy and scanning it on every (node × item) candidate pair per maintain pass.

The counter is tracked on instanceof ContinuedTask (stable over the buildable lifecycle) rather than the dynamic isContinued() value, so drift is impossible in the increment/decrement direction. An @Initializer reconciles the counter after JOB_LOADED to cover items restored from queue.xml at startup (the exact case ContinuedTask exists for). Any missed callback would only cause the fast path to miss and fall through to the original scan — correctness is preserved.

We're trying to solve for https://github.com/jenkinsci/durable-task-plugin/issues/560. 
A performance improvement in the spirit of https://github.com/jenkinsci/durable-task-plugin/pull/563. 

### Testing done

Includes unit tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
